### PR TITLE
patch: [DPE-9185] [DPE-9401] Port plugin & keystore managers and SMTP integration

### DIFF
--- a/opensearch_single_kernel/charms/base.py
+++ b/opensearch_single_kernel/charms/base.py
@@ -22,13 +22,18 @@ from opensearch_single_kernel.events.custom_events import (
     RestartOpenSearch,
     StartOpenSearch,
 )
+from opensearch_single_kernel.events.keystore import KeystoreEventsHandler
+from opensearch_single_kernel.events.notifications import NotificationsEvents
 from opensearch_single_kernel.events.opensearch import OpenSearchEventsHandler
 from opensearch_single_kernel.events.tls import TLSEventsHandler
 from opensearch_single_kernel.managers.cluster import ClusterManager
 from opensearch_single_kernel.managers.config import ConfigManager
 from opensearch_single_kernel.managers.exclusions import NodesExclusionsManager
 from opensearch_single_kernel.managers.health import HealthManager
+from opensearch_single_kernel.managers.keystore import KeystoreManager
 from opensearch_single_kernel.managers.lock import LockManager
+from opensearch_single_kernel.managers.notification import NotificationsManager
+from opensearch_single_kernel.managers.plugin import PluginManager
 from opensearch_single_kernel.managers.profiles import ProfilesManager
 from opensearch_single_kernel.managers.tls import TlsManager
 from opensearch_single_kernel.managers.users import UsersManager
@@ -62,10 +67,15 @@ class OpenSearchBaseCharm(ops.CharmBase, ABC):
         self.profiles_manager = ProfilesManager(self.state, self.workload)
         self.health_manager = HealthManager(self.state, self.workload)
         self.config_manager = ConfigManager(self.state, self.workload)
+        self.keystore_manager = KeystoreManager(self.state, self.workload)
+        self.plugin_manager = PluginManager(self.state, self.workload)
+        self.notifications_manager = NotificationsManager(self.state, self.workload)
 
         # Event Handlers
         self.opensearch_events = OpenSearchEventsHandler(self)
         self.tls_events = TLSEventsHandler(self)
+        self.keystore_events = KeystoreEventsHandler(self)
+        self.notifications_events = NotificationsEvents(self)
 
     def trigger_peer_rel_changed(
         self,

--- a/opensearch_single_kernel/charms/base.py
+++ b/opensearch_single_kernel/charms/base.py
@@ -19,6 +19,7 @@ from opensearch_single_kernel.common.exceptions import (
 from opensearch_single_kernel.common.statuses import CharmStatuses
 from opensearch_single_kernel.core.state import ClusterState
 from opensearch_single_kernel.events.custom_events import (
+    ReloadKeystoreEvent,
     RestartOpenSearch,
     StartOpenSearch,
 )
@@ -48,6 +49,7 @@ class OpenSearchBaseCharm(ops.CharmBase, ABC):
 
     restart_opensearch_event = EventSource(RestartOpenSearch)
     start_opensearch_event = EventSource(StartOpenSearch)
+    reload_keystore_event = EventSource(ReloadKeystoreEvent)
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/opensearch_single_kernel/common/client.py
+++ b/opensearch_single_kernel/common/client.py
@@ -602,8 +602,7 @@ class OpenSearchClient:
             self.request("GET", f"/_plugins/_notifications/configs/{config_id}")
             return True
         except OpenSearchHttpError as exc:
-            code = getattr(exc, "response_code", None)
-            if code == 404:
+            if getattr(exc, "response_code", None) == 404:
                 return False
             raise
 
@@ -635,7 +634,8 @@ class OpenSearchClient:
     def delete_notification_config(self, config_id: str) -> None:
         """Delete config by id.
 
-        404 (config already gone) is treated as success.
+        If the request returns code 404 (config already gone)
+        it is treated as success and function returns.
 
         Args:
             config_id: Notification Config ID
@@ -651,7 +651,7 @@ class OpenSearchClient:
         """Reload secure settings. Doesn't throw an exception.
 
         Returns:
-            whether operation was successful.
+            bool: whether operation was successful.
         """
         try:
             response = self.request("POST", "_nodes/reload_secure_settings")

--- a/opensearch_single_kernel/common/client.py
+++ b/opensearch_single_kernel/common/client.py
@@ -33,7 +33,11 @@ class OpenSearchClient:
     """Handle OpenSearch Interaction with Server."""
 
     def __init__(
-        self, workload: BaseWorkload, host: str, port: int, admin_secret: str | None = None
+        self,
+        workload: BaseWorkload,
+        host: str,
+        port: int,
+        admin_secret: str | None = None,
     ):
         """Initialise the client.
 
@@ -554,7 +558,11 @@ class OpenSearchClient:
             raise OpenSearchHttpError(response_text=str(e))
 
     def get_log_error_http_retry(
-        self, retry_max: int, method: str, urls: list[str], payload: dict[str, Any] | None
+        self,
+        retry_max: int,
+        method: str,
+        urls: list[str],
+        payload: dict[str, Any] | None,
     ):
         """Return a custom log function to run before a new Tenacity retry."""
 
@@ -567,3 +575,88 @@ class OpenSearchClient:
             )
 
         return log_error
+
+    def create_notification_config(
+        self, *, config_id: str, name: str, config: dict[str, object]
+    ) -> None:
+        """Create notification config.
+
+        Args:
+            config_id: Notification Config ID
+            name: Notification Name
+            config: Notification Config
+        """
+        payload = {"config_id": config_id, "name": name, "config": config}
+        self.request("POST", "/_plugins/_notifications/configs/", payload=payload)
+
+    def notification_config_exists(self, config_id: str) -> bool:
+        """Check if config exists.
+
+        Args:
+            config_id: Notification Config ID
+
+        Returns:
+            True if config exists, False if 404.
+        """
+        try:
+            self.request("GET", f"/_plugins/_notifications/configs/{config_id}")
+            return True
+        except OpenSearchHttpError as exc:
+            code = getattr(exc, "response_code", None)
+            if code == 404:
+                return False
+            raise
+
+    def create_or_update_notification_config(
+        self, *, config_id: str, name: str, config: dict[str, object]
+    ) -> None:
+        """Create config if missing, otherwise update.
+
+        Args:
+            config_id: Notification Config ID
+            name: Notification Name
+            config: Notification Config
+        """
+        if self.notification_config_exists(config_id):
+            self.update_notification_config(config_id=config_id, config=config)
+        else:
+            self.create_notification_config(config_id=config_id, name=name, config=config)
+
+    def update_notification_config(self, *, config_id: str, config: dict[str, object]) -> None:
+        """Update notification config.
+
+        Args:
+            config_id: Notification Config ID
+            config: Notification Config
+        """
+        payload = {"config": config}
+        self.request("PUT", f"/_plugins/_notifications/configs/{config_id}", payload=payload)
+
+    def delete_notification_config(self, config_id: str) -> None:
+        """Delete config by id.
+
+        404 (config already gone) is treated as success.
+
+        Args:
+            config_id: Notification Config ID
+        """
+        try:
+            self.request("DELETE", f"/_plugins/_notifications/configs/{config_id}")
+        except OpenSearchHttpError as exc:
+            code = getattr(exc, "response_code", None)
+            if code == 404:
+                return
+            raise
+
+    def reload_secure_settings(self) -> bool:
+        """Reload secure settings. Doesn't throw an exception.
+
+        Returns:
+            whether operation was successful.
+        """
+        try:
+            response = self.request("POST", "_nodes/reload_secure_settings")
+        except OpenSearchHttpError as e:
+            logger.error("Could not reload secure settings: %s", e)
+            return False
+        return isinstance(response, dict) and response.get("_nodes", {}).get("failed", -1) == 0

--- a/opensearch_single_kernel/common/client.py
+++ b/opensearch_single_kernel/common/client.py
@@ -607,7 +607,7 @@ class OpenSearchClient:
                 return False
             raise
 
-    def create_or_update_notification_config(
+    def put_notification_config(
         self, *, config_id: str, name: str, config: dict[str, object]
     ) -> None:
         """Create config if missing, otherwise update.
@@ -643,8 +643,7 @@ class OpenSearchClient:
         try:
             self.request("DELETE", f"/_plugins/_notifications/configs/{config_id}")
         except OpenSearchHttpError as exc:
-            code = getattr(exc, "response_code", None)
-            if code == 404:
+            if getattr(exc, "response_code", None) == 404:
                 return
             raise
 

--- a/opensearch_single_kernel/common/constants.py
+++ b/opensearch_single_kernel/common/constants.py
@@ -180,6 +180,7 @@ AZURE_PEER_SECRET_KEYS = [
     AZURE_CREDENTIALS,
 ]
 GCS_CREDENTIALS = "gcs-creds"
+SMTP_SECRET_LABEL = "plugin-notifications"
 
 
 # Messages

--- a/opensearch_single_kernel/common/constants.py
+++ b/opensearch_single_kernel/common/constants.py
@@ -5,7 +5,6 @@
 
 """OpenSearch Charm literals."""
 
-
 from opensearch_single_kernel.utils.enum import BaseStrEnum
 
 
@@ -103,6 +102,22 @@ class TlsFileExt(BaseStrEnum):
     CSR = ".csr"
     KEY = ".key"
     KEYPASS = ".key-password"
+
+
+class SmtpTransportSecurity(BaseStrEnum):
+    """SMTP transport security protocol.
+
+    Enum values match relation data (smtp-integrator). api_method() maps to
+    OpenSearch Notifications API strings (start_tls, ssl).
+    """
+
+    NONE = "none"
+    STARTTLS = "starttls"
+    TLS = "tls"
+
+    def api_method(self) -> str:
+        """Return the OpenSearch Notifications API method string."""
+        return {"none": "none", "starttls": "start_tls", "tls": "ssl"}[self.value]
 
 
 class OpenSearchPaths(BaseStrEnum):

--- a/opensearch_single_kernel/common/exceptions.py
+++ b/opensearch_single_kernel/common/exceptions.py
@@ -4,7 +4,6 @@
 
 """Charm-specific exceptions."""
 
-
 import json
 from typing import Optional
 
@@ -90,3 +89,13 @@ class OpenSearchExclusionsException(OpenSearchError):
 
 class OpenSearchFileOperationError(OpenSearchError):
     """Exception thrown when file operations related to OpenSearch fail."""
+
+
+class OpenSearchSmtpMissingParametersError(OpenSearchError):
+    """Exception thrown if there are missing parameters when generating smtp config."""
+
+    def __init__(self, missing_parameters: list[str]) -> None:
+        self.missing_parameters = missing_parameters
+        super().__init__(
+            f"Parameters missing from smtp-integrator: {', '.join(missing_parameters)}"
+        )

--- a/opensearch_single_kernel/common/statuses.py
+++ b/opensearch_single_kernel/common/statuses.py
@@ -5,6 +5,7 @@
 
 This module defines various status enums that represent the state of the charm.
 """
+
 from enum import Enum
 
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
@@ -92,3 +93,21 @@ class CharmStatuses(Enum):
     DATA_ROLE_REMOVAL_FORBIDDEN = BlockedStatus(
         "Removal of data role from current deployment not allowed - the data cannot be reallocated."
     )
+
+    # Notifications
+    SMTP_RELATION_INVALID = BlockedStatus(
+        "SMTP relation must be established with the main-orchestrator cluster."
+    )
+    SMTP_WAITING_RECIPIENTS = WaitingStatus(
+        "SMTP sender configured; waiting for recipients to create email group/channel."
+    )
+    SMTP_NO_RELATION_DATA = BlockedStatus(
+        "Relation to smtp-integrator has no data. Configure smtp-integrator and check unit logs."
+    )
+    SMTP_CONFIGURATION_ERROR = BlockedStatus(
+        "SMTP configuration failed. Check smtp-integrator and unit logs."
+    )
+    SMTP_MISSING_REQUIRED_PARAMETERS = BlockedStatus(
+        "Parameters missing from smtp-integrator: {params}."
+    )
+    SMTP_COULD_NOT_READ_DATA = BlockedStatus("Could not read smtp relation data: {exc}.")

--- a/opensearch_single_kernel/core/models.py
+++ b/opensearch_single_kernel/core/models.py
@@ -21,11 +21,9 @@ from opensearch_single_kernel.common.constants import (
     DeploymentType,
     Directive,
     PerformanceType,
+    SmtpTransportSecurity,
     StartMode,
     State,
-)
-from opensearch_single_kernel.lib.charms.smtp_integrator.v0.smtp import (
-    TransportSecurity,
 )
 
 logger = logging.getLogger(__name__)
@@ -386,9 +384,7 @@ class PluginConfigInfo(Model):
         """Merge items into cleanup dictionary avoiding duplicates."""
         for key, items in cleanup.items():
             current = self.cleanup.setdefault(key, [])
-            for item in items:
-                if item not in current:
-                    current.append(item)
+            current = sorted(list(set(current) | set(items)))
 
 
 @dataclass(frozen=True)
@@ -409,4 +405,4 @@ class SmtpConfig:
     label: str
     group_id: str
     channel_id: str
-    transport_security: TransportSecurity
+    transport_security: SmtpTransportSecurity

--- a/opensearch_single_kernel/core/models.py
+++ b/opensearch_single_kernel/core/models.py
@@ -5,10 +5,10 @@
 
 """Collection of models used for the operation of the charm."""
 
-
 import json
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from hashlib import md5
 from typing import Any, Iterator, Literal
@@ -23,6 +23,9 @@ from opensearch_single_kernel.common.constants import (
     PerformanceType,
     StartMode,
     State,
+)
+from opensearch_single_kernel.lib.charms.smtp_integrator.v0.smtp import (
+    TransportSecurity,
 )
 
 logger = logging.getLogger(__name__)
@@ -308,7 +311,8 @@ class OpenSearchProfile(ABC):
         """Get the JVM heap size in KB based on the memory requirements."""
         if self.memory_requirements.jvm_heap_percentage:
             return min(
-                int(self.memory_requirements.jvm_heap_percentage * mem_size), MAX_HEAP_SIZE_IN_KB
+                int(self.memory_requirements.jvm_heap_percentage * mem_size),
+                MAX_HEAP_SIZE_IN_KB,
             )
         return _1GB_IN_KB
 
@@ -385,3 +389,24 @@ class PluginConfigInfo(Model):
             for item in items:
                 if item not in current:
                     current.append(item)
+
+
+@dataclass(frozen=True)
+class SmtpConfig:
+    """SMTP-related config derived from relation data.
+
+    Attributes:
+        sender_email: From-address for the SMTP sender (relation smtp_sender).
+        smtp_account_id: OpenSearch config id for the SMTP account (e.g. smtp-88_smtp-account).
+        label: Plugin/config label for this relation (e.g. plugin-notifications-88).
+        group_id: OpenSearch config id for the recipient group (e.g. smtp-88_recipients).
+        channel_id: OpenSearch config id for the email channel (e.g. smtp-88_email-channel).
+        transport_security: SMTP transport security (none, start_tls, tls).
+    """
+
+    sender_email: str
+    smtp_account_id: str
+    label: str
+    group_id: str
+    channel_id: str
+    transport_security: TransportSecurity

--- a/opensearch_single_kernel/core/models.py
+++ b/opensearch_single_kernel/core/models.py
@@ -384,7 +384,7 @@ class PluginConfigInfo(Model):
         """Merge items into cleanup dictionary avoiding duplicates."""
         for key, items in cleanup.items():
             current = self.cleanup.setdefault(key, [])
-            current = sorted(list(set(current) | set(items)))
+            self.cleanup[key] = sorted(list(set(current) | set(items)))
 
 
 @dataclass(frozen=True)

--- a/opensearch_single_kernel/core/models.py
+++ b/opensearch_single_kernel/core/models.py
@@ -369,3 +369,19 @@ class TestingProfile(OpenSearchProfile):
             cluster_managers=1,
             data=1,
         )
+
+
+class PluginConfigInfo(Model):
+    """Model class for representing data needed to add or remove plugin configuration"""
+
+    relation_name: str | None = None
+    secret_id: str | None = None
+    cleanup: dict[str, list[str]] = Field(default_factory=dict)
+
+    def add_cleanup_items(self, cleanup: dict[str, list[str]]) -> None:
+        """Merge items into cleanup dictionary avoiding duplicates."""
+        for key, items in cleanup.items():
+            current = self.cleanup.setdefault(key, [])
+            for item in items:
+                if item not in current:
+                    current.append(item)

--- a/opensearch_single_kernel/core/relations.py
+++ b/opensearch_single_kernel/core/relations.py
@@ -233,6 +233,33 @@ class RelationState:
             except KeyError:
                 pass
 
+    def get_object(self, key: str) -> dict[str, Any] | None:
+        """Get dict / json object from the relation data store."""
+        data = self.relation_data.get(key)
+        if data is None:
+            return None
+
+        return json.loads(data)
+
+    def put_object(self, key: str, value: dict[str, Any], merge: bool = False) -> None:
+        """Put dict / json object into relation data store."""
+        if merge:
+            stored = self.get_object(key)
+
+            if stored is not None:
+                stored.update(value)
+                value = stored
+
+        sorted_value = Model.sort_payload(value)
+
+        payload_str = None
+        if value is not None:
+            payload_str = json.dumps(
+                sorted_value, default=RelationDataStore._default_encoder, sort_keys=True
+            )
+
+        self.update({key: payload_str})
+
 
 class PeerClusterOrchestratorData(ProviderData, RequirerData):
     """Orchestrator provider data model."""

--- a/opensearch_single_kernel/core/relations.py
+++ b/opensearch_single_kernel/core/relations.py
@@ -4,6 +4,7 @@
 # See LICENSE file for licensing details.
 
 """Base classes for charm relations."""
+
 import enum
 import json
 import logging
@@ -235,20 +236,13 @@ class RelationState:
 
     def get_object(self, key: str) -> dict[str, Any] | None:
         """Get dict / json object from the relation data store."""
-        data = self.relation_data.get(key)
-        if data is None:
-            return None
-
-        return json.loads(data)
+        return json.loads(data) if (data := self.relation_data.get(key)) is not None else None
 
     def put_object(self, key: str, value: dict[str, Any], merge: bool = False) -> None:
         """Put dict / json object into relation data store."""
-        if merge:
-            stored = self.get_object(key)
-
-            if stored is not None:
-                stored.update(value)
-                value = stored
+        if merge and (stored := self.get_object(key)) is not None:
+            stored.update(value)
+            value = stored
 
         sorted_value = Model.sort_payload(value)
 

--- a/opensearch_single_kernel/core/secrets.py
+++ b/opensearch_single_kernel/core/secrets.py
@@ -237,10 +237,30 @@ class OpenSearchSecrets(Object, RelationDataStore):
 
         logger.debug(f"Deleted secret {scope}:{key}")
 
+    def get_tracked_secret(self, secret_id: str, scope: Scope, key: str) -> Secret | None:
+        """Track a granted secret and add it to the cache"""
+        label = self.label(scope, key)
+        if cached_secret_meta := self.cached_secrets.get_meta(scope, label):
+            # already tracking
+            return cached_secret_meta
+        try:
+            secret = self._charm.model.get_secret(id=secret_id)
+        except SecretNotFoundError:
+            logger.info("Could not find secret: %s - %s", key, secret_id)
+            return None
+
+        self.cached_secrets.set_meta(scope, label, secret)
+        self.cached_secrets.put_content(scope, label, secret.get_content(refresh=True))
+        return secret
+
     def get_secret_id(self, scope: Scope, key: str) -> str | None:
         """Get the secret ID from the cache."""
         label = self.label(scope, key)
-        return self.charm.peers_data.get(scope, label)
+        return (
+            self.charm.state.application.relation_data.get(label)
+            if scope == Scope.APP
+            else self.charm.state.server.relation_data.get(label)
+        )
 
     def grant_secret_to_relation(self, secret_id: str, relation: Relation):
         """Grant a secret to a relation."""

--- a/opensearch_single_kernel/core/state.py
+++ b/opensearch_single_kernel/core/state.py
@@ -8,7 +8,7 @@
 import json
 import logging
 import socket
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ops import Application, JujuVersion, Object, Relation, Unit
 
@@ -29,11 +29,11 @@ from opensearch_single_kernel.common.constants import (
 from opensearch_single_kernel.core.models import (
     DeploymentDescription,
     DeploymentType,
-    Model,
     Node,
     OpenSearchProfile,
     PeerClusterApp,
     PerformanceType,
+    PluginConfigInfo,
     ProductionProfile,
     TestingProfile,
 )
@@ -41,7 +41,6 @@ from opensearch_single_kernel.core.relations import (
     PeerCluster,
     PeerClusterData,
     PeerClusterOrchestratorData,
-    RelationDataStore,
     RelationState,
 )
 from opensearch_single_kernel.core.secrets import OpenSearchSecrets
@@ -211,6 +210,23 @@ class OpenSearchServer(RelationState):
         """Set the value of last configured IP for the unit. Used for tracking the IP change."""
         self.update({"last_host_ip": value})
 
+    @property
+    def plugin_config_info(self) -> dict[str, PluginConfigInfo]:
+        """Returns configuration information for plugins this app is managing"""
+        plugin_config_info = self.get_object("plugin_config_info") or {}
+        return {
+            label: PluginConfigInfo.from_dict(plugin)
+            for label, plugin in plugin_config_info.items()
+        }
+
+    @plugin_config_info.setter
+    def plugin_config_info(self, value: dict[str, PluginConfigInfo]) -> None:
+        """Returns configuration information for plugins this app is managing"""
+        if not value:
+            self.update({"plugin_config_info": ""})
+            return
+        self.put_object("plugin_config_info", value)
+
 
 class OpenSearchApplication(RelationState):
     """An OpenSearch Application is a charm application with a given role.
@@ -224,33 +240,6 @@ class OpenSearchApplication(RelationState):
     ):
         super().__init__(relation, data_interface, component)
         self.app = component
-
-    def get_object(self, key: str) -> dict[str, Any] | None:
-        """Get dict / json object from the relation data store."""
-        data = self.relation_data.get(key)
-        if data is None:
-            return None
-
-        return json.loads(data)
-
-    def put_object(self, key: str, value: dict[str, Any], merge: bool = False) -> None:
-        """Put dict / json object into relation data store."""
-        if merge:
-            stored = self.get_object(key)
-
-            if stored is not None:
-                stored.update(value)
-                value = stored
-
-        sorted_value = Model.sort_payload(value)
-
-        payload_str = None
-        if value is not None:
-            payload_str = json.dumps(
-                sorted_value, default=RelationDataStore._default_encoder, sort_keys=True
-            )
-
-        self.update({key: payload_str})
 
     @property
     def name(self) -> str:
@@ -373,6 +362,23 @@ class OpenSearchApplication(RelationState):
         """Look for data-role through all the roles of all the nodes in all applications"""
         data_apps_in_fleet = [app for app in self.apps_in_fleet() if "data" in app.roles]
         return data_apps_in_fleet and any(app.planned_units > 0 for app in data_apps_in_fleet)
+
+    @property
+    def plugin_config_info(self) -> dict[str, PluginConfigInfo]:
+        """Returns configuration information for plugins this app is managing"""
+        plugin_config_info = self.get_object("plugin_config_info") or {}
+        return {
+            label: PluginConfigInfo.from_dict(plugin)
+            for label, plugin in plugin_config_info.items()
+        }
+
+    @plugin_config_info.setter
+    def plugin_config_info(self, value: dict[str, PluginConfigInfo]) -> None:
+        """Returns configuration information for plugins this app is managing"""
+        if not value:
+            self.update({"plugin_config_info": ""})
+            return
+        self.put_object("plugin_config_info", value)
 
 
 class ClusterState(Object):

--- a/opensearch_single_kernel/core/state.py
+++ b/opensearch_single_kernel/core/state.py
@@ -212,7 +212,7 @@ class OpenSearchServer(RelationState):
 
     @property
     def plugin_config_info(self) -> dict[str, PluginConfigInfo]:
-        """Returns configuration information for plugins this app is managing"""
+        """Returns configuration information for plugins this unit is managing"""
         plugin_config_info = self.get_object("plugin_config_info") or {}
         return {
             label: PluginConfigInfo.from_dict(plugin)
@@ -221,7 +221,7 @@ class OpenSearchServer(RelationState):
 
     @plugin_config_info.setter
     def plugin_config_info(self, value: dict[str, PluginConfigInfo]) -> None:
-        """Returns configuration information for plugins this app is managing"""
+        """Returns configuration information for plugins this unit is managing"""
         if not value:
             self.update({"plugin_config_info": ""})
             return

--- a/opensearch_single_kernel/events/custom_events.py
+++ b/opensearch_single_kernel/events/custom_events.py
@@ -17,7 +17,12 @@ class StartOpenSearch(EventBase):
     """
 
     def __init__(
-        self, handle, *, ignore_lock=False, after_upgrade=False, is_first_data_node=False
+        self,
+        handle,
+        *,
+        ignore_lock=False,
+        after_upgrade=False,
+        is_first_data_node=False,
     ):
         super().__init__(handle)
         self.ignore_lock = ignore_lock
@@ -44,3 +49,7 @@ class RestartOpenSearch(EventBase):
 
     This event will be deferred until OpenSearch stops. Then, `_StartOpenSearch` will be emitted.
     """
+
+
+class ReloadKeystoreEvent(EventBase):
+    """Event to signal that the keystore should be reloaded."""

--- a/opensearch_single_kernel/events/keystore.py
+++ b/opensearch_single_kernel/events/keystore.py
@@ -9,7 +9,7 @@ This module manages OpenSearch keystore access and lifecycle.
 import logging
 from typing import TYPE_CHECKING
 
-from ops import EventSource, Object
+from ops import Object
 
 from opensearch_single_kernel.events.custom_events import ReloadKeystoreEvent
 
@@ -22,17 +22,15 @@ logger = logging.getLogger(__name__)
 class KeystoreEventsHandler(Object):
     """Keystore events."""
 
-    reload_event = EventSource(ReloadKeystoreEvent)
-
     def __init__(
         self,
         charm: "OpenSearchBaseCharm",
     ) -> None:
         """Initialize keystore events."""
-        super().__init__(charm, key="opensearch_keystore_events")
+        super().__init__(charm, key="keystore_events")
         self.charm = charm
 
-        self.framework.observe(self.reload_event, self._on_reload)
+        self.framework.observe(self.charm.reload_keystore_event, self._on_reload)
 
     def _on_reload(self, event: ReloadKeystoreEvent) -> None:
         """Handle keystore reload event."""

--- a/opensearch_single_kernel/events/keystore.py
+++ b/opensearch_single_kernel/events/keystore.py
@@ -1,0 +1,41 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Implements the keystore logic.
+
+This module manages OpenSearch keystore access and lifecycle.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+from ops import EventSource, Object
+
+from opensearch_single_kernel.events.custom_events import ReloadKeystoreEvent
+
+if TYPE_CHECKING:
+    from opensearch_single_kernel.charms.base import OpenSearchBaseCharm
+
+logger = logging.getLogger(__name__)
+
+
+class KeystoreEventsHandler(Object):
+    """Keystore events."""
+
+    reload_event = EventSource(ReloadKeystoreEvent)
+
+    def __init__(
+        self,
+        charm: "OpenSearchBaseCharm",
+    ) -> None:
+        """Initialize keystore events."""
+        super().__init__(charm, key="opensearch_keystore_events")
+        self.charm = charm
+
+        self.framework.observe(self.reload_event, self._on_reload)
+
+    def _on_reload(self, event: ReloadKeystoreEvent) -> None:
+        """Handle keystore reload event."""
+        if not self.charm.keystore_manager.reload():
+            logger.error("Keystore reload failed.")
+            event.defer()

--- a/opensearch_single_kernel/events/notifications.py
+++ b/opensearch_single_kernel/events/notifications.py
@@ -23,7 +23,10 @@ from opensearch_single_kernel.common.constants import (
     DeploymentType,
     Scope,
 )
-from opensearch_single_kernel.common.exceptions import OpenSearchHttpError
+from opensearch_single_kernel.common.exceptions import (
+    OpenSearchHttpError,
+    OpenSearchSmtpMissingParametersError,
+)
 from opensearch_single_kernel.common.statuses import CharmStatuses
 from opensearch_single_kernel.lib.charms.data_platform_libs.v0.data_interfaces import (
     SecretError,
@@ -35,7 +38,6 @@ from opensearch_single_kernel.lib.charms.smtp_integrator.v0.smtp import (
     SmtpDataAvailableEvent,
     SmtpRequires,
 )
-from opensearch_single_kernel.managers.notification import NotificationsClientError
 from opensearch_single_kernel.utils.helpers import decode_plugin_secret_content
 from opensearch_single_kernel.utils.status import Status
 
@@ -51,7 +53,7 @@ class NotificationsEvents(Object):
     relation_name = SMTP_RELATION
 
     def __init__(self, charm: "OpenSearchBaseCharm"):
-        super().__init__(charm, "plugin:notifications")
+        super().__init__(charm, "notifications_events")
         self.charm = charm
         self.smtp = SmtpRequires(self.charm, self.relation_name)
 
@@ -68,7 +70,7 @@ class NotificationsEvents(Object):
         Args:
             event: Smtp credentials available event
         """
-        parameters = None
+        smtp_data = None
         if not (deployment_desc := self.charm.state.application.deployment_desc):
             logger.debug("Deployment not ready. Deferring event.")
             event.defer()
@@ -85,7 +87,7 @@ class NotificationsEvents(Object):
             return
 
         try:
-            parameters = self.smtp.get_relation_data_from_relation(event.relation)
+            smtp_data = self.smtp.get_relation_data_from_relation(event.relation)
         except SecretError as exc:
             logger.error(f"Could not read smtp relation data: {exc}")
             if self.charm.unit.is_leader():
@@ -103,57 +105,42 @@ class NotificationsEvents(Object):
                 pattern=Status.CheckPattern.Interpolated,
             )
 
-        if not parameters:
+        if not smtp_data:
             if self.charm.unit.is_leader():
                 self.charm.status.set(CharmStatuses.SMTP_NO_RELATION_DATA, app=True)
             return
         if self.charm.unit.is_leader():
             self.charm.status.clear(CharmStatuses.SMTP_NO_RELATION_DATA, app=True)
 
-        missing = []
-        if not parameters.smtp_sender:
-            missing.append("smtp_sender")
-        if not parameters.host:
-            missing.append("host")
-        if not parameters.port:
-            missing.append("port")
-        if not parameters.transport_security:
-            missing.append("transport_security")
-        if parameters.auth_type != "none":
-            if not parameters.user:
-                missing.append("user")
-            if not parameters.password:
-                missing.append("password")
-
-        if missing:
+        try:
+            config = self.charm.notifications_manager.get_smtp_config(smtp_data, event.relation.id)
+        except OpenSearchSmtpMissingParametersError as e:
             if self.charm.unit.is_leader():
                 self.charm.status.set(
                     CharmStatuses.SMTP_MISSING_REQUIRED_PARAMETERS,
                     app=True,
-                    dynamic_params={"params": ", ".join(missing)},
+                    dynamic_params={"params": ", ".join(e.missing_parameters)},
                 )
-                return
-
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(
-                CharmStatuses.SMTP_MISSING_REQUIRED_PARAMETERS,
-                pattern=Status.CheckPattern.Interpolated,
-                app=True,
-            )
-
-        config = self.charm.notifications_manager.get_smtp_config(parameters, event.relation.id)
+            return
+        else:
+            if self.charm.unit.is_leader():
+                self.charm.status.clear(
+                    CharmStatuses.SMTP_MISSING_REQUIRED_PARAMETERS,
+                    pattern=Status.CheckPattern.Interpolated,
+                    app=True,
+                )
 
         # create/update SMTP sender config (config_id is relation-based)
         if self.charm.unit.is_leader():
             try:
                 self.charm.notifications_manager.put_smtp_sender(
                     smtp_account_id=config.smtp_account_id,
-                    host=parameters.host,
-                    port=parameters.port,
+                    host=smtp_data.host,
+                    port=smtp_data.port,
                     transport_security=config.transport_security,
                     from_address=config.sender_email,
                 )
-            except NotificationsClientError as e:
+            except OpenSearchHttpError as e:
                 logger.error(
                     "Failed to create SMTP sender with smtp_account_id: %s with Error: %s",
                     config.smtp_account_id,
@@ -168,16 +155,16 @@ class NotificationsEvents(Object):
 
             self.charm.status.clear(CharmStatuses.SMTP_CONFIGURATION_ERROR, app=True)
 
-        if parameters.auth_type != "none":
+        if smtp_data.auth_type != "none":
             # store keystore creds on every unit
             entries = {
-                f"opensearch.notifications.core.email.{config.smtp_account_id}.username": parameters.user,
-                f"opensearch.notifications.core.email.{config.smtp_account_id}.password": parameters.password,
+                f"opensearch.notifications.core.email.{config.smtp_account_id}.username": smtp_data.user,
+                f"opensearch.notifications.core.email.{config.smtp_account_id}.password": smtp_data.password,
             }
             self.charm.keystore_manager.put_entries(entries)
 
             # reload secure settings
-            self.charm.keystore_events.reload_event.emit()
+            self.charm.reload_keystore_event.emit()
             # store cleanup info per relation
             cleanup = {
                 "keys": list(entries.keys()),
@@ -208,11 +195,11 @@ class NotificationsEvents(Object):
         if not self.charm.unit.is_leader():
             return
         # create recipient group and email channel if recipients are provided
-        if parameters.recipients:
+        if smtp_data.recipients:
             try:
                 self.charm.notifications_manager.put_email_group(
                     group_id=config.group_id,
-                    recipients=[str(r) for r in parameters.recipients],
+                    recipients=[str(r) for r in smtp_data.recipients],
                 )
                 self.charm.notifications_manager.put_email_channel(
                     channel_id=config.channel_id,
@@ -220,7 +207,7 @@ class NotificationsEvents(Object):
                     email_group_ids=[config.group_id],
                     fallback_recipients=[],
                 )
-            except NotificationsClientError as e:
+            except OpenSearchHttpError as e:
                 logger.error(
                     "Failed to create SMTP email channel with group: %s with Error: %s",
                     config.group_id,
@@ -289,14 +276,16 @@ class NotificationsEvents(Object):
             group_id = self.charm.notifications_manager.recipient_group_id(smtp_account_id)
             for config_id in (channel_id, group_id, smtp_account_id):
                 try:
-                    self.charm.notifications_manager.delete_config(config_id)
+                    self.charm.notifications_manager.opensearch_client.delete_notification_config(
+                        config_id
+                    )
                 except OpenSearchHttpError:
                     logger.exception("Failed deleting notifications config %s", config_id)
 
         # Keystore cleanup after configs: keys may be absent when smtp_account_id exists
         if keys:
             self.charm.keystore_manager.remove_entries(keys)
-            self.charm.keystore_events.reload_event.emit()
+            self.charm.reload_keystore_event.emit()
 
         self.charm.plugin_manager.remove_plugin_config(scope=Scope.UNIT, label=label)
 
@@ -342,4 +331,4 @@ class NotificationsEvents(Object):
         )
 
         self.charm.keystore_manager.put_entries(keys)
-        self.charm.keystore_events.reload_event.emit()
+        self.charm.reload_keystore_event.emit()

--- a/opensearch_single_kernel/events/notifications.py
+++ b/opensearch_single_kernel/events/notifications.py
@@ -1,0 +1,345 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""SMTP integration for the OpenSearch charm.
+
+NotificationsEvents: handles the smtp-integrator relation (credentials available,
+  relation broken, secret changed). Validates SMTP parameters, creates/updates
+  OpenSearch notification configs and keystore entries, and cleans up on
+  relation break.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from ops.charm import RelationBrokenEvent, SecretChangedEvent
+from ops.framework import Object
+
+from opensearch_single_kernel.common.constants import (
+    SMTP_SECRET_LABEL,
+    DeploymentType,
+    Scope,
+)
+from opensearch_single_kernel.common.exceptions import OpenSearchHttpError
+from opensearch_single_kernel.common.statuses import CharmStatuses
+from opensearch_single_kernel.lib.charms.data_platform_libs.v0.data_interfaces import (
+    SecretError,
+)
+from opensearch_single_kernel.lib.charms.smtp_integrator.v0.smtp import (
+    DEFAULT_RELATION_NAME as SMTP_RELATION,
+)
+from opensearch_single_kernel.lib.charms.smtp_integrator.v0.smtp import (
+    SmtpDataAvailableEvent,
+    SmtpRequires,
+)
+from opensearch_single_kernel.managers.notification import NotificationsClientError
+from opensearch_single_kernel.utils.helpers import decode_plugin_secret_content
+from opensearch_single_kernel.utils.status import Status
+
+if TYPE_CHECKING:
+    from opensearch_single_kernel.charms.base import OpenSearchBaseCharm
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationsEvents(Object):
+    """Events handler for smtp events"""
+
+    relation_name = SMTP_RELATION
+
+    def __init__(self, charm: "OpenSearchBaseCharm"):
+        super().__init__(charm, "plugin:notifications")
+        self.charm = charm
+        self.smtp = SmtpRequires(self.charm, self.relation_name)
+
+        self.framework.observe(self.smtp.on.smtp_data_available, self._on_smtp_credentials_changed)
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_broken,
+            self._on_smtp_credentials_gone,
+        )
+        self.framework.observe(self.charm.on.secret_changed, self._on_secret_changed)
+
+    def _on_smtp_credentials_changed(self, event: SmtpDataAvailableEvent) -> None:  # noqa: C901
+        """Configure notifications sender/group/channel and keystore creds for this relation.
+
+        Args:
+            event: Smtp credentials available event
+        """
+        parameters = None
+        if not (deployment_desc := self.charm.state.application.deployment_desc):
+            logger.debug("Deployment not ready. Deferring event.")
+            event.defer()
+            return
+
+        if deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            if self.charm.unit.is_leader():
+                self.charm.status.set(CharmStatuses.SMTP_RELATION_INVALID, app=True)
+            return
+
+        if not self.charm.cluster_manager.opensearch_client.is_node_up():
+            logger.debug("OpenSearch is not ready yet. Deferring event.")
+            event.defer()
+            return
+
+        try:
+            parameters = self.smtp.get_relation_data_from_relation(event.relation)
+        except SecretError as exc:
+            logger.error(f"Could not read smtp relation data: {exc}")
+            if self.charm.unit.is_leader():
+                self.charm.status.set(
+                    CharmStatuses.SMTP_COULD_NOT_READ_DATA,
+                    app=True,
+                    dynamic_params={"exc": str(exc)},
+                )
+                return
+
+        if self.charm.unit.is_leader():
+            self.charm.status.clear(
+                CharmStatuses.SMTP_COULD_NOT_READ_DATA,
+                app=True,
+                pattern=Status.CheckPattern.Interpolated,
+            )
+
+        if not parameters:
+            if self.charm.unit.is_leader():
+                self.charm.status.set(CharmStatuses.SMTP_NO_RELATION_DATA, app=True)
+            return
+        if self.charm.unit.is_leader():
+            self.charm.status.clear(CharmStatuses.SMTP_NO_RELATION_DATA, app=True)
+
+        missing = []
+        if not parameters.smtp_sender:
+            missing.append("smtp_sender")
+        if not parameters.host:
+            missing.append("host")
+        if not parameters.port:
+            missing.append("port")
+        if not parameters.transport_security:
+            missing.append("transport_security")
+        if parameters.auth_type != "none":
+            if not parameters.user:
+                missing.append("user")
+            if not parameters.password:
+                missing.append("password")
+
+        if missing:
+            if self.charm.unit.is_leader():
+                self.charm.status.set(
+                    CharmStatuses.SMTP_MISSING_REQUIRED_PARAMETERS,
+                    app=True,
+                    dynamic_params={"params": ", ".join(missing)},
+                )
+                return
+
+        if self.charm.unit.is_leader():
+            self.charm.status.clear(
+                CharmStatuses.SMTP_MISSING_REQUIRED_PARAMETERS,
+                pattern=Status.CheckPattern.Interpolated,
+                app=True,
+            )
+
+        config = self.charm.notifications_manager.get_smtp_config(parameters, event.relation.id)
+
+        # create/update SMTP sender config (config_id is relation-based)
+        if self.charm.unit.is_leader():
+            try:
+                self.charm.notifications_manager.put_smtp_sender(
+                    smtp_account_id=config.smtp_account_id,
+                    host=parameters.host,
+                    port=parameters.port,
+                    transport_security=config.transport_security,
+                    from_address=config.sender_email,
+                )
+            except NotificationsClientError as e:
+                logger.error(
+                    "Failed to create SMTP sender with smtp_account_id: %s with Error: %s",
+                    config.smtp_account_id,
+                    str(e),
+                )
+                self.charm.status.set(
+                    CharmStatuses.SMTP_CONFIGURATION_ERROR,
+                    app=True,
+                )
+                event.defer()
+                return
+
+            self.charm.status.clear(CharmStatuses.SMTP_CONFIGURATION_ERROR, app=True)
+
+        if parameters.auth_type != "none":
+            # store keystore creds on every unit
+            entries = {
+                f"opensearch.notifications.core.email.{config.smtp_account_id}.username": parameters.user,
+                f"opensearch.notifications.core.email.{config.smtp_account_id}.password": parameters.password,
+            }
+            self.charm.keystore_manager.put_entries(entries)
+
+            # reload secure settings
+            self.charm.keystore_events.reload_event.emit()
+            # store cleanup info per relation
+            cleanup = {
+                "keys": list(entries.keys()),
+                "smtp_account_id": [config.smtp_account_id],
+            }
+            self.charm.plugin_manager.put_plugin_config(
+                scope=Scope.UNIT, label=config.label, cleanup=cleanup
+            )
+
+            if self.charm.unit.is_leader():
+                # leader stores secret for subclusters for per relation
+                self.charm.plugin_manager.store_plugin_secret(
+                    content={
+                        "keys": entries,
+                        "smtp_account_id": cleanup["smtp_account_id"],
+                    },
+                    label=config.label,
+                    relation_name=self.relation_name,
+                )
+        else:
+            # No keystore entries for auth_type "none", still store smtp_account_id for cleanup
+            self.charm.plugin_manager.put_plugin_config(
+                scope=Scope.UNIT,
+                label=config.label,
+                cleanup={"smtp_account_id": [config.smtp_account_id]},
+            )
+
+        if not self.charm.unit.is_leader():
+            return
+        # create recipient group and email channel if recipients are provided
+        if parameters.recipients:
+            try:
+                self.charm.notifications_manager.put_email_group(
+                    group_id=config.group_id,
+                    recipients=[str(r) for r in parameters.recipients],
+                )
+                self.charm.notifications_manager.put_email_channel(
+                    channel_id=config.channel_id,
+                    smtp_account_id=config.smtp_account_id,
+                    email_group_ids=[config.group_id],
+                    fallback_recipients=[],
+                )
+            except NotificationsClientError as e:
+                logger.error(
+                    "Failed to create SMTP email channel with group: %s with Error: %s",
+                    config.group_id,
+                    str(e),
+                )
+                self.charm.status.set(
+                    CharmStatuses.SMTP_CONFIGURATION_ERROR,
+                    app=True,
+                )
+                event.defer()
+                return
+            self.charm.status.clear(CharmStatuses.SMTP_WAITING_RECIPIENTS, app=True)
+            self.charm.status.clear(CharmStatuses.SMTP_CONFIGURATION_ERROR, app=True)
+        else:
+            self.charm.status.set(CharmStatuses.SMTP_WAITING_RECIPIENTS, app=True)
+
+        # propagate to subclusters if this is the main provider
+        # if self.charm.opensearch_peer_cm.is_provider(typ="main"):
+        #     self.charm.peer_cluster_provider.refresh_relation_data(event)
+
+    def _on_smtp_credentials_gone(self, event: RelationBrokenEvent) -> None:  # noqa: C901
+        """Cleanup for a broken smtp relation (relation-scoped).
+
+        Args:
+            event: RelationBrokenEvent
+        """
+        if self.charm.unit.is_leader():
+            self.charm.status.clear(CharmStatuses.SMTP_RELATION_INVALID, app=True)
+            self.charm.status.clear(CharmStatuses.SMTP_CONFIGURATION_ERROR, app=True)
+            self.charm.status.clear(CharmStatuses.SMTP_NO_RELATION_DATA, app=True)
+            self.charm.status.clear(
+                CharmStatuses.SMTP_MISSING_REQUIRED_PARAMETERS,
+                pattern=Status.CheckPattern.Interpolated,
+                app=True,
+            )
+            self.charm.status.clear(
+                CharmStatuses.SMTP_COULD_NOT_READ_DATA,
+                pattern=Status.CheckPattern.Interpolated,
+                app=True,
+            )
+
+        label = self.charm.notifications_manager.label(event.relation.id)
+        plugin_config = self.charm.state.server.plugin_config_info.get(label)
+        if not plugin_config:
+            return
+        cleanup = plugin_config.cleanup or {}
+        # smtp_account_id is always stored per relation, keys only when auth is used
+        # if no keys, smtp_account_id may still exist
+        keys = list(cleanup.get("keys", []))
+        smtp_account_ids = cleanup.get("smtp_account_id")
+        smtp_account_id = smtp_account_ids[0] if smtp_account_ids else None
+
+        # No smtp_account_id; nothing to clean in keystore or notifications
+        if not smtp_account_id:
+            self.charm.plugin_manager.remove_plugin_config(scope=Scope.UNIT, label=label)
+            if self.charm.unit.is_leader():
+                self.charm.plugin_manager.remove_plugin_secret(label)
+                # if self.charm.opensearch_peer_cm.is_provider(typ="main"):
+                #     self.charm.peer_cluster_provider.refresh_relation_data(event)
+            return
+
+        # Delete notification configs first so we never have configs that reference
+        # missing keystore credentials (channel -> group -> smtp account dependency order)
+        if self.charm.unit.is_leader():
+            channel_id = self.charm.notifications_manager.email_channel_id(smtp_account_id)
+            group_id = self.charm.notifications_manager.recipient_group_id(smtp_account_id)
+            for config_id in (channel_id, group_id, smtp_account_id):
+                try:
+                    self.charm.notifications_manager.delete_config(config_id)
+                except OpenSearchHttpError:
+                    logger.exception("Failed deleting notifications config %s", config_id)
+
+        # Keystore cleanup after configs: keys may be absent when smtp_account_id exists
+        if keys:
+            self.charm.keystore_manager.remove_entries(keys)
+            self.charm.keystore_events.reload_event.emit()
+
+        self.charm.plugin_manager.remove_plugin_config(scope=Scope.UNIT, label=label)
+
+        if not self.charm.unit.is_leader():
+            return
+
+        self.charm.plugin_manager.remove_plugin_secret(label)
+
+        # if self.charm.opensearch_peer_cm.is_provider(typ="main"):
+        #     self.charm.peer_cluster_provider.refresh_relation_data(event)
+
+    def _on_secret_changed(self, event: SecretChangedEvent) -> None:
+        """Handles secret changes (support multiple smtp relations).
+
+        Args:
+            event: SecretChangedEvent
+        """
+        label = event.secret.label
+
+        if not label or SMTP_SECRET_LABEL not in label:
+            return
+
+        content = event.secret.get_content(refresh=True)
+
+        if not (match := re.search(r"(plugin-notifications-\d+)", event.secret.label)):
+            return
+        label = match.group(1)
+
+        if not (plugin_config := decode_plugin_secret_content(content, label)):
+            return
+
+        if not (keys := plugin_config.get("keys")):
+            return
+
+        smtp_account_id_list = plugin_config.get("smtp_account_id") or []
+        self.charm.plugin_manager.put_plugin_config(
+            scope=Scope.UNIT,
+            label=label,
+            cleanup={
+                "keys": list(keys.keys()),
+                "smtp_account_id": smtp_account_id_list,
+            },
+        )
+
+        self.charm.keystore_manager.put_entries(keys)
+        self.charm.keystore_events.reload_event.emit()

--- a/opensearch_single_kernel/events/notifications.py
+++ b/opensearch_single_kernel/events/notifications.py
@@ -157,33 +157,16 @@ class NotificationsEvents(Object):
 
         if smtp_data.auth_type != "none":
             # store keystore creds on every unit
-            entries = {
-                f"opensearch.notifications.core.email.{config.smtp_account_id}.username": smtp_data.user,
-                f"opensearch.notifications.core.email.{config.smtp_account_id}.password": smtp_data.password,
-            }
-            self.charm.keystore_manager.put_entries(entries)
+            credentials = self.charm.keystore_manager.put_notifications_plugin_smtp_credentials(
+                config.smtp_account_id, smtp_data.user, smtp_data.password
+            )
 
             # reload secure settings
             self.charm.reload_keystore_event.emit()
             # store cleanup info per relation
-            cleanup = {
-                "keys": list(entries.keys()),
-                "smtp_account_id": [config.smtp_account_id],
-            }
-            self.charm.plugin_manager.put_plugin_config(
-                scope=Scope.UNIT, label=config.label, cleanup=cleanup
+            self.charm.plugin_manager.put_notifications_plugin_smtp_config(
+                config, credentials, self.charm.unit.is_leader(), self.relation_name
             )
-
-            if self.charm.unit.is_leader():
-                # leader stores secret for subclusters for per relation
-                self.charm.plugin_manager.store_plugin_secret(
-                    content={
-                        "keys": entries,
-                        "smtp_account_id": cleanup["smtp_account_id"],
-                    },
-                    label=config.label,
-                    relation_name=self.relation_name,
-                )
         else:
             # No keystore entries for auth_type "none", still store smtp_account_id for cleanup
             self.charm.plugin_manager.put_plugin_config(
@@ -298,7 +281,7 @@ class NotificationsEvents(Object):
         #     self.charm.peer_cluster_provider.refresh_relation_data(event)
 
     def _on_secret_changed(self, event: SecretChangedEvent) -> None:
-        """Handles secret changes (support multiple smtp relations).
+        """Handles smtp secrets changes (support multiple smtp relations).
 
         Args:
             event: SecretChangedEvent

--- a/opensearch_single_kernel/events/notifications.py
+++ b/opensearch_single_kernel/events/notifications.py
@@ -70,6 +70,7 @@ class NotificationsEvents(Object):
         Args:
             event: Smtp credentials available event
         """
+        is_leader = self.charm.unit.is_leader()
         smtp_data = None
         if not (deployment_desc := self.charm.state.application.deployment_desc):
             logger.debug("Deployment not ready. Deferring event.")
@@ -77,7 +78,7 @@ class NotificationsEvents(Object):
             return
 
         if deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
-            if self.charm.unit.is_leader():
+            if is_leader:
                 self.charm.status.set(CharmStatuses.SMTP_RELATION_INVALID, app=True)
             return
 
@@ -90,7 +91,7 @@ class NotificationsEvents(Object):
             smtp_data = self.smtp.get_relation_data_from_relation(event.relation)
         except SecretError as exc:
             logger.error(f"Could not read smtp relation data: {exc}")
-            if self.charm.unit.is_leader():
+            if is_leader:
                 self.charm.status.set(
                     CharmStatuses.SMTP_COULD_NOT_READ_DATA,
                     app=True,
@@ -98,7 +99,7 @@ class NotificationsEvents(Object):
                 )
                 return
 
-        if self.charm.unit.is_leader():
+        if is_leader:
             self.charm.status.clear(
                 CharmStatuses.SMTP_COULD_NOT_READ_DATA,
                 app=True,
@@ -106,10 +107,10 @@ class NotificationsEvents(Object):
             )
 
         if not smtp_data:
-            if self.charm.unit.is_leader():
+            if is_leader:
                 self.charm.status.set(CharmStatuses.SMTP_NO_RELATION_DATA, app=True)
             return
-        if self.charm.unit.is_leader():
+        if is_leader:
             self.charm.status.clear(CharmStatuses.SMTP_NO_RELATION_DATA, app=True)
 
         try:

--- a/opensearch_single_kernel/events/plugin.py
+++ b/opensearch_single_kernel/events/plugin.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Handler for TLS events."""
+"""Handler for plugins events."""
 
 import logging
 from typing import TYPE_CHECKING
@@ -30,7 +30,7 @@ class PluginEventsHandler(Object):
     """Events handler for OpenSearch plugin events"""
 
     def __init__(self, charm: "OpenSearchBaseCharm"):
-        super().__init__(charm, "plugins")
+        super().__init__(charm, "plugin_events")
         self.charm = charm
         self.framework.observe(
             self.charm.on[PEER_RELATION].relation_changed,

--- a/opensearch_single_kernel/events/plugin.py
+++ b/opensearch_single_kernel/events/plugin.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for TLS events."""
+
+import logging
+from typing import TYPE_CHECKING
+
+from ops import (
+    Object,
+)
+
+from opensearch_single_kernel.common.constants import (
+    PEER_RELATION,
+    Scope,
+)
+from opensearch_single_kernel.utils.helpers import (
+    decode_plugin_secret_content,
+    diff,
+)
+
+if TYPE_CHECKING:
+    from opensearch_single_kernel.charms.base import OpenSearchBaseCharm
+
+logger = logging.getLogger(__name__)
+
+
+class PluginEventsHandler(Object):
+    """Events handler for OpenSearch plugin events"""
+
+    def __init__(self, charm: "OpenSearchBaseCharm"):
+        super().__init__(charm, "plugins")
+        self.charm = charm
+        self.framework.observe(
+            self.charm.on[PEER_RELATION].relation_changed,
+            self._on_peer_relation_changed,
+        )
+
+    def _on_peer_relation_changed(self, event):  # noqa: C901
+        """Handle plugin secret-related peer relation changes."""
+        # if this is a subcluster, all units must add plugin keys from secrets to their keystores
+        # if not self.charm.opensearch_peer_cm.is_consumer(of="main"):
+        #     return
+        return
+
+        app_plugins = self.charm.state.application.plugin_config_info
+        unit_plugins = self.charm.state.server.plugin_config_info
+        added, removed = diff(app_plugins.keys(), unit_plugins.keys())
+        for label in added:
+            plugin = app_plugins[label]
+            if not plugin.secret_id:
+                continue
+
+            # start locally tracking secret and write transferred keys to keystore
+            content = self.charm.state.secrets.get_tracked_secret(
+                plugin.secret_id, Scope.APP, label
+            ).get_content()
+            if not (plugin_config := decode_plugin_secret_content(content, label)):
+                continue
+
+            keys_to_add = plugin_config.get("keys")
+
+            self.charm.keystore_manager.put_entries(keys_to_add)
+            cleanup = {"keys": list(keys_to_add.keys())}
+            # store on unit for later removal (only keys needed and not values)
+            self.charm.plugin_manager.put_plugin_config(
+                scope=Scope.UNIT, label=label, cleanup=cleanup
+            )
+
+        for label in removed:
+            # this unit should delete the keys it wrote as the app secret has been removed
+            cleanup = unit_plugins[label].cleanup
+            for key, items in cleanup.items():
+                if key == "keys":
+                    self.charm.keystore_manager.remove_entries(items)
+
+        # reload keystore
+        self.charm.keystore_events.reload_event.emit()
+
+        for label in removed:
+            self.charm.plugin_manager.remove_plugin_config(scope=Scope.UNIT, label=label)

--- a/opensearch_single_kernel/lib/charms/smtp_integrator/v0/smtp.py
+++ b/opensearch_single_kernel/lib/charms/smtp_integrator/v0/smtp.py
@@ -1,0 +1,558 @@
+# Copyright 2025 Canonical Ltd.
+# Licensed under the Apache2.0. See LICENSE file in charm source for details.
+
+"""Library to manage the integration with the SMTP Integrator charm.
+
+This library contains the Requires and Provides classes for handling the integration
+between an application and a charm providing the `smtp` and `smtp-legacy` integrations.
+If the requirer charm supports secrets, the preferred approach is to use the `smtp`
+relation to leverage them.
+This library also contains a `SmtpRelationData` class to wrap the SMTP data that will
+be shared via the integration.
+
+### Requirer Charm
+
+```python
+
+from charms.smtp_integrator.v0.smtp import SmtpDataAvailableEvent, SmtpRequires
+
+class SmtpRequirerCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.smtp = smtp.SmtpRequires(self)
+        self.framework.observe(self.smtp.on.smtp_data_available, self._handler)
+        ...
+
+    def _handler(self, events: SmtpDataAvailableEvent) -> None:
+        ...
+
+```
+
+As shown above, the library provides a custom event to handle the scenario in
+which new SMTP data has been added or updated.
+
+### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+from charms.smtp_integrator.v0.smtp import SmtpProvides
+
+class SmtpProviderCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.smtp = SmtpProvides(self)
+        ...
+
+```
+The SmtpProvides object wraps the list of relations into a `relations` property
+and provides an `update_relation_data` method to update the relation data by passing
+a `SmtpRelationData` data object.
+
+```python
+class SmtpProviderCharm(ops.CharmBase):
+    ...
+
+    def _on_config_changed(self, _) -> None:
+        for relation in self.model.relations[self.smtp.relation_name]:
+            self.smtp.update_relation_data(relation, self._get_smtp_data())
+
+```
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "09583c2f9c1d4c0f9a40244cfc20b0c2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 21
+
+PYDEPS = ["pydantic>=1.10,<3", "email-validator>=2"]
+
+# pylint: disable=wrong-import-position
+import itertools
+import json
+import logging
+import typing
+from ast import literal_eval
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
+
+import ops
+from pydantic import BaseModel, EmailStr, Field, ValidationError
+
+logger = logging.getLogger(__name__)
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+try:
+    # Pydantic v2
+    from pydantic import field_validator as _pyd_field_validator
+
+    _PYDANTIC_V2 = True
+except ImportError:
+    _pyd_field_validator = None  # type: ignore[assignment]
+    _PYDANTIC_V2 = False
+
+# Pydantic v1 field validation decorator (v2 uses field_validator)
+from pydantic import validator as _pyd_validator  # type: ignore[attr-defined]
+
+DEFAULT_RELATION_NAME = "smtp"
+LEGACY_RELATION_NAME = "smtp-legacy"
+
+
+def recipients_validator() -> Callable[[_F], _F]:
+    """Return the correct recipients validator decorator for pydantic v1/v2.
+
+    Returns:
+        A decorator to validate/normalize the recipients field before EmailStr validation.
+    """
+    if _PYDANTIC_V2:
+        return cast(Any, _pyd_field_validator)("recipients", mode="before")
+    return cast(Any, _pyd_validator)("recipients", pre=True)
+
+
+class SmtpError(Exception):
+    """Common ancestor for Smtp related exceptions."""
+
+
+class SecretError(SmtpError):
+    """Common ancestor for Secrets related exceptions."""
+
+
+class TransportSecurity(str, Enum):
+    """Represent the transport security values.
+
+    Attributes:
+        NONE: none
+        STARTTLS: starttls
+        TLS: tls
+    """
+
+    NONE = "none"
+    STARTTLS = "starttls"
+    TLS = "tls"
+
+
+class AuthType(str, Enum):
+    """Represent the auth type values.
+
+    Attributes:
+        NONE: none
+        NOT_PROVIDED: not_provided
+        PLAIN: plain
+    """
+
+    NONE = "none"
+    NOT_PROVIDED = "not_provided"
+    PLAIN = "plain"
+
+
+class SmtpRelationData(BaseModel):
+    """Represent the relation data.
+
+    Attributes:
+        host: The hostname or IP address of the outgoing SMTP relay.
+        port: The port of the outgoing SMTP relay.
+        user: The SMTP AUTH user to use for the outgoing SMTP relay.
+        password: The SMTP AUTH password to use for the outgoing SMTP relay.
+        password_id: The secret ID where the SMTP AUTH password for the SMTP relay is stored.
+        auth_type: The type used to authenticate with the SMTP relay.
+        transport_security: The security protocol to use for the outgoing SMTP relay.
+        domain: The domain used by the emails sent from SMTP relay.
+        skip_ssl_verify: Specifies if certificate trust verification is skipped in the SMTP relay.
+        smtp_sender: Optional sender email address for outgoing notifications.
+        recipients: List of recipient email addresses for notifications.
+    """
+
+    host: str = Field(..., min_length=1)
+    port: int = Field(..., ge=1, le=65536)
+    user: Optional[str] = None
+    password: Optional[str] = None
+    password_id: Optional[str] = None
+    auth_type: AuthType
+    transport_security: TransportSecurity
+    domain: Optional[str] = None
+    skip_ssl_verify: Optional[bool] = False
+    smtp_sender: Optional[EmailStr] = None
+    recipients: List[EmailStr] = Field(default_factory=list)
+
+    @recipients_validator()
+    @classmethod
+    def _recipients_str_to_list(cls, value: Any) -> Any:
+        """Convert recipients input to list[str] before EmailStr validation."""
+        return parse_recipients(value)
+
+    def to_relation_data(self) -> Dict[str, str]:
+        """Convert an instance of SmtpRelationData to the relation representation.
+
+        Returns:
+            Dict containing the representation.
+        """
+        result = {
+            "host": str(self.host),
+            "port": str(self.port),
+            "auth_type": self.auth_type.value,
+            "transport_security": self.transport_security.value,
+            "skip_ssl_verify": str(self.skip_ssl_verify),
+        }
+        if self.domain:
+            result["domain"] = self.domain
+        if self.user:
+            result["user"] = self.user
+        if self.password:
+            result["password"] = self.password
+        if self.password_id:
+            if "password" in result:
+                logger.warning("password field exists along with password_id field, removing.")
+                del result["password"]
+            result["password_id"] = self.password_id
+
+        if self.smtp_sender:
+            result["smtp_sender"] = str(self.smtp_sender)
+
+        if self.recipients:
+            recipients = list(self.recipients)
+            result["recipients"] = json.dumps([str(r) for r in recipients])
+
+        return result
+
+
+class SmtpDataAvailableEvent(ops.RelationEvent):
+    """Smtp event emitted when relation data has changed.
+
+    Attributes:
+        host: The hostname or IP address of the outgoing SMTP relay.
+        port: The port of the outgoing SMTP relay.
+        user: The SMTP AUTH user to use for the outgoing SMTP relay.
+        password: The SMTP AUTH password to use for the outgoing SMTP relay.
+        password_id: The secret ID where the SMTP AUTH password for the SMTP relay is stored.
+        auth_type: The type used to authenticate with the SMTP relay.
+        transport_security: The security protocol to use for the outgoing SMTP relay.
+        domain: The domain used by the emails sent from SMTP relay.
+        skip_ssl_verify: Specifies if certificate trust verification is skipped in the SMTP relay.
+        smtp_sender: Optional sender email address for outgoing notifications.
+        recipients: List of recipient email addresses for notifications.
+    """
+
+    @property
+    def host(self) -> str:
+        """Fetch the SMTP host from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("host"))
+
+    @property
+    def port(self) -> int:
+        """Fetch the SMTP port from the relation."""
+        assert self.relation.app
+        return int(typing.cast(str, self.relation.data[self.relation.app].get("port")))
+
+    @property
+    def user(self) -> str:
+        """Fetch the SMTP user from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("user"))
+
+    @property
+    def password(self) -> str:
+        """Fetch the SMTP password from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("password"))
+
+    @property
+    def password_id(self) -> str:
+        """Fetch the SMTP password from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("password_id"))
+
+    @property
+    def auth_type(self) -> AuthType:
+        """Fetch the SMTP auth type from the relation."""
+        assert self.relation.app
+        return AuthType(self.relation.data[self.relation.app].get("auth_type"))
+
+    @property
+    def transport_security(self) -> TransportSecurity:
+        """Fetch the SMTP transport security protocol from the relation."""
+        assert self.relation.app
+        return TransportSecurity(self.relation.data[self.relation.app].get("transport_security"))
+
+    @property
+    def domain(self) -> str:
+        """Fetch the SMTP domain from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("domain"))
+
+    @property
+    def skip_ssl_verify(self) -> bool:
+        """Fetch the skip_ssl_verify flag from the relation."""
+        assert self.relation.app
+        return literal_eval(
+            typing.cast(str, self.relation.data[self.relation.app].get("skip_ssl_verify"))
+        )
+
+    @property
+    def smtp_sender(self) -> Optional[str]:
+        """Fetch the SMTP sender from the relation.
+
+        Returns:
+            smtp_sender: Optional sender email address for outgoing notifications.
+        """
+        assert self.relation.app
+        return self.relation.data[self.relation.app].get("smtp_sender")
+
+    @property
+    def recipients(self) -> List[str]:
+        """Fetch the SMTP recipients from the relation.
+
+        Returns:
+            recipients: list of recipient email addresses for notifications.
+        """
+        assert self.relation.app
+        raw = self.relation.data[self.relation.app].get("recipients")
+        return parse_recipients(raw)
+
+
+class SmtpRequiresEvents(ops.CharmEvents):
+    """SMTP events.
+
+    This class defines the events that a SMTP requirer can emit.
+
+    Attributes:
+        smtp_data_available: the SmtpDataAvailableEvent.
+    """
+
+    smtp_data_available = ops.EventSource(SmtpDataAvailableEvent)
+
+
+class SmtpRequires(ops.Object):
+    """Requirer side of the SMTP relation.
+
+    Attributes:
+        on: events the provider can emit.
+    """
+
+    on = SmtpRequiresEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on.secret_changed, self._on_secret_changed)
+
+    def get_relation_data(self) -> Optional[SmtpRelationData]:
+        """Retrieve the relation data.
+
+        Returns:
+            SmtpRelationData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        return self.get_relation_data_from_relation(relation) if relation else None
+
+    def get_relation_data_from_relation(
+        self, relation: ops.Relation
+    ) -> Optional[SmtpRelationData]:
+        """Retrieve the relation data.
+
+        Args:
+            relation: the relation to retrieve the data from.
+
+        Returns:
+            SmtpRelationData: the relation data.
+
+        Raises:
+            SecretError: if the secret can't be read.
+        """
+        assert relation.app
+        raw_relation_data = relation.data[relation.app]
+        if not raw_relation_data:
+            return None
+
+        data: Dict[str, Any] = dict(raw_relation_data)
+
+        password = data.get("password")
+        if password is None and data.get("password_id"):
+            try:
+                password = (
+                    self.model.get_secret(id=data["password_id"])
+                    .get_content(refresh=True)
+                    .get("password")
+                )
+            except ops.model.ModelError as exc:
+                raise SecretError(f"Could not consume secret {data.get('password_id')}") from exc
+
+        # normalize recipients
+        data["recipients"] = parse_recipients(data.get("recipients"))
+
+        return SmtpRelationData(**{**data, "password": password})
+
+    def _is_relation_data_valid(self, relation: ops.Relation) -> bool:
+        """Validate the relation data.
+
+        Args:
+            relation: the relation to validate.
+
+        Returns:
+            true: if the relation data is valid.
+        """
+        try:
+            _ = self.get_relation_data_from_relation(relation)
+            return True
+        except ValidationError as ex:
+            error_fields = set(
+                itertools.chain.from_iterable(error["loc"] for error in ex.errors())
+            )
+            error_field_str = " ".join(f"{f}" for f in error_fields)
+            logger.warning("Error validation the relation data %s", error_field_str)
+            return False
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Handle the relation changed event.
+
+        Args:
+            event: event triggering this handler.
+        """
+        assert event.relation.app
+        relation_data = event.relation.data[event.relation.app]
+        if relation_data:
+            if relation_data["auth_type"] == AuthType.NONE.value:
+                logger.warning('Insecure setting: auth_type has a value "none"')
+            if relation_data["transport_security"] == TransportSecurity.NONE.value:
+                logger.warning('Insecure setting: transport_security has value "none"')
+            if self._is_relation_data_valid(event.relation):
+                self.on.smtp_data_available.emit(event.relation, app=event.app, unit=event.unit)
+
+    @staticmethod
+    def _secret_uri_equal(left: str, right: str) -> bool:
+        """Check if two juju secret URIs are equal."""
+        left_without_protocol = left.removeprefix("secret://")
+        left_without_protocol = left_without_protocol.removeprefix("secret:")
+        right_without_protocol = right.removeprefix("secret://")
+        right_without_protocol = right_without_protocol.removeprefix("secret:")
+        # If they are both fully qualified secret URLs, compare them directly
+        if "/" in left_without_protocol and "/" in right_without_protocol:
+            return left_without_protocol == right_without_protocol
+        # Otherwise, compare only the secret ID part and ignore the potential model UUID
+        left_id = left_without_protocol.split("/")[-1]
+        right_id = right_without_protocol.split("/")[-1]
+        return left_id == right_id
+
+    def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
+        """Handle the relation secret event."""
+        changed_secret_uri = event.secret.id
+        if changed_secret_uri is None:
+            return
+        for relation in self.charm.model.relations[self.relation_name]:
+            if relation.app is None:
+                continue
+            relation_data = relation.data[relation.app]
+            password_id = relation_data.get("password_id")
+            if not password_id:
+                continue
+            try:
+                secret = self.model.get_secret(id=password_id)
+            except ops.ModelError:
+                continue
+            secret_uri = secret.id
+            if secret_uri is None:
+                continue
+            if self._secret_uri_equal(changed_secret_uri, secret_uri):
+                self.on.smtp_data_available.emit(relation, app=relation.app, unit=None)
+
+
+class SmtpProvides(ops.Object):
+    """Provider side of the SMTP relation."""
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def update_relation_data(self, relation: ops.Relation, smtp_data: SmtpRelationData) -> None:
+        """Update the relation data.
+
+        Args:
+            relation: the relation for which to update the data.
+            smtp_data: a SmtpRelationData instance wrapping the data to be updated.
+        """
+        new_data = smtp_data.to_relation_data()
+        if new_data["auth_type"] == AuthType.NONE.value:
+            logger.warning('Insecure setting: auth_type has a value "none"')
+        if new_data["transport_security"] == TransportSecurity.NONE.value:
+            logger.warning('Insecure setting: transport_security has value "none"')
+        relation_data = relation.data[self.charm.model.app]
+        if dict(relation_data) != dict(new_data):
+            logger.info("update data in relation id:%s", relation.id)
+            relation_data.clear()
+            relation_data.update(new_data)
+
+
+def parse_recipients(raw: Any) -> list[str]:
+    """Normalize SMTP recipient input into a list of email strings.
+
+    The function produces a normalized list[str] so that downstream validation (EmailStr)
+    can be applied consistently.
+
+    Args:
+        raw: Recipient input as received from relation data, charm config,
+            May be None, str, or list.
+
+    Accepted input forms:
+        - None or empty string
+        - list of stripped string values
+        - JSON list string
+        - Comma-separated string
+        - Single address string
+
+    Returns:
+        A list of recipient strings. The email correctness is validated later by EmailStr.
+
+    Raises:
+        TypeError: If raw is not None, str or list.
+        ValueError: If a JSON-encoded value does not decode to a list.
+    """
+    if raw is None:
+        return []
+
+    if isinstance(raw, list):
+        return [str(x).strip() for x in raw if str(x).strip()]
+
+    if not isinstance(raw, str):
+        raise TypeError("recipients must be a string, list, or None")
+
+    s = raw.strip()
+    if not s:
+        return []
+
+    # JSON list string
+    if s.startswith("["):
+        loaded = json.loads(s)
+        if not isinstance(loaded, list):
+            raise ValueError("recipients JSON must decode to a list")
+        return [str(x).strip() for x in loaded if str(x).strip()]
+
+    # JSON without a bracelet: '"a@x.com", "b@y.com"'
+    if '"' in s and "," in s:
+        loaded = json.loads(f"[{s}]")
+        if not isinstance(loaded, list):
+            raise ValueError("recipients must decode to a list")
+        return [str(x).strip() for x in loaded if str(x).strip()]
+
+    # comma-separated or single
+    return [p.strip() for p in s.split(",") if p.strip()]

--- a/opensearch_single_kernel/managers/keystore.py
+++ b/opensearch_single_kernel/managers/keystore.py
@@ -45,6 +45,21 @@ class KeystoreManager(BaseManager):
         """Add a new file entry in the keystore."""
         self.workload.run_cmd(self.KEYSTORE, f"add-file {key} {filename} --force")
 
+    def put_notifications_plugin_smtp_credentials(
+        self, account_id: str, user: str | None, password: str | None
+    ) -> dict[str, str]:
+        """Build a smtp credential entries and put them in the keystore.
+
+        Returns:
+            built smtp credentials entries.
+        """
+        entries = {
+            f"opensearch.notifications.core.email.{account_id}.username": user or "",
+            f"opensearch.notifications.core.email.{account_id}.password": password or "",
+        }
+        self.put_entries(entries)
+        return entries
+
     def remove_entries(self, keys: list[str]) -> None:
         """Remove entries from the keystore."""
         self._create_if_needed()

--- a/opensearch_single_kernel/managers/keystore.py
+++ b/opensearch_single_kernel/managers/keystore.py
@@ -1,0 +1,88 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Implements the keystore logic.
+
+This module manages OpenSearch keystore access and lifecycle.
+"""
+
+import logging
+
+from opensearch_single_kernel.common.exceptions import (
+    OpenSearchCmdError,
+    OpenSearchHttpError,
+)
+from opensearch_single_kernel.core.state import ClusterState
+from opensearch_single_kernel.managers.base import BaseManager
+from opensearch_single_kernel.workload.base import BaseWorkload
+
+logger = logging.getLogger(__name__)
+
+
+class KeystoreManager(BaseManager):
+    """Manages keystore."""
+
+    KEYSTORE = "opensearch.keystore"
+
+    def __init__(self, state: ClusterState, workload: BaseWorkload):
+        """Creates the keystore manager class."""
+        super().__init__(state, workload)
+        self.name = "keystore_manager"
+
+    def _create_if_needed(self) -> None:
+        """Creates the keystore if not already present."""
+        if self.workload.paths.opensearch_keystore.exists():
+            return
+
+        self.workload.run_cmd(self.KEYSTORE, "create")
+
+    def put_entries(self, entries: dict[str, str]) -> None:
+        """Add new key/val entries on the keystore."""
+        for key, val in entries.items():
+            # adding the '--force' flag will create the keystore if not present
+            self.workload.run_cmd(self.KEYSTORE, f"add {key} --force", stdin=val)
+
+    def put_file_entry(self, key: str, filename: str) -> None:
+        """Add a new file entry in the keystore."""
+        self.workload.run_cmd(self.KEYSTORE, f"add-file {key} {filename} --force")
+
+    def remove_entries(self, keys: list[str]) -> None:
+        """Remove entries from the keystore."""
+        self._create_if_needed()
+
+        for key in keys:
+            if key == "keystore.seed":
+                continue
+
+            try:
+                self.workload.run_cmd(self.KEYSTORE, f"remove {key}")
+            except OpenSearchCmdError as e:
+                err_text = e.err or ""
+                if "does not exist in the keystore" in err_text:
+                    continue
+                raise
+
+    def list_keys(self) -> list[str]:
+        """List all keys in the keystore."""
+        self._create_if_needed()
+        return self.workload.run_cmd(self.KEYSTORE, "list").splitlines()
+
+    def reload(self) -> bool:
+        """Reload the keystore."""
+        self._create_if_needed()
+        self.workload.run_cmd(self.KEYSTORE, "upgrade")
+
+        if not self.workload.is_service_started():
+            # service not running, settings will be picked up at startup
+            logger.debug("Opensearch not running. Keystore settings will be loaded at start time.")
+            return True
+
+        try:
+            response = self.opensearch_client.request("POST", "_nodes/reload_secure_settings")
+        except OpenSearchHttpError as e:
+            logger.error("Could not reload secure settings: %s", e)
+            return False
+
+        success = response.get("_nodes", {}).get("failed", -1) == 0
+        logger.debug("keystore reloaded: %s", success)
+        return success

--- a/opensearch_single_kernel/managers/keystore.py
+++ b/opensearch_single_kernel/managers/keystore.py
@@ -10,7 +10,6 @@ import logging
 
 from opensearch_single_kernel.common.exceptions import (
     OpenSearchCmdError,
-    OpenSearchHttpError,
 )
 from opensearch_single_kernel.core.state import ClusterState
 from opensearch_single_kernel.managers.base import BaseManager
@@ -68,7 +67,11 @@ class KeystoreManager(BaseManager):
         return self.workload.run_cmd(self.KEYSTORE, "list").splitlines()
 
     def reload(self) -> bool:
-        """Reload the keystore."""
+        """Reload the keystore.
+
+        Returns:
+            whether a reload was successful.
+        """
         self._create_if_needed()
         self.workload.run_cmd(self.KEYSTORE, "upgrade")
 
@@ -77,12 +80,8 @@ class KeystoreManager(BaseManager):
             logger.debug("Opensearch not running. Keystore settings will be loaded at start time.")
             return True
 
-        try:
-            response = self.opensearch_client.request("POST", "_nodes/reload_secure_settings")
-        except OpenSearchHttpError as e:
-            logger.error("Could not reload secure settings: %s", e)
+        if not self.opensearch_client.reload_secure_settings():
             return False
 
-        success = response.get("_nodes", {}).get("failed", -1) == 0
-        logger.debug("keystore reloaded: %s", success)
-        return success
+        logger.debug("Keystore reload successful")
+        return True

--- a/opensearch_single_kernel/managers/notification.py
+++ b/opensearch_single_kernel/managers/notification.py
@@ -1,0 +1,336 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""OpenSearch Notifications plugin API client (configs CRUD).
+
+This client wraps OpenSearchDistribution.request() to manage notifications configs:
+- smtp sender (config_type: smtp_account)
+- email group (config_type: email_group)
+- email channel (config_type: email)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+from opensearch_single_kernel.common.constants import SMTP_SECRET_LABEL
+from opensearch_single_kernel.common.exceptions import OpenSearchHttpError
+from opensearch_single_kernel.core.state import ClusterState
+from opensearch_single_kernel.lib.charms.smtp_integrator.v0.smtp import SmtpRelationData
+from opensearch_single_kernel.managers.base import BaseManager
+from opensearch_single_kernel.workload.base import BaseWorkload
+
+
+class NotificationsClientError(RuntimeError):
+    """Raises when Notifications API operations fail."""
+
+
+class TransportSecurity(str, Enum):
+    """SMTP transport security protocol.
+
+    Enum values match relation data (smtp-integrator). api_method() maps to
+    OpenSearch Notifications API strings (start_tls, ssl).
+    """
+
+    NONE = "none"
+    STARTTLS = "starttls"
+    TLS = "tls"
+
+    def api_method(self) -> str:
+        """Return the OpenSearch Notifications API method string."""
+        return {"none": "none", "starttls": "start_tls", "tls": "ssl"}[self.value]
+
+
+@dataclass(frozen=True)
+class SmtpConfig:
+    """SMTP-related config derived from relation data.
+
+    Attributes:
+        sender_email: From-address for the SMTP sender (relation smtp_sender).
+        smtp_account_id: OpenSearch config id for the SMTP account (e.g. smtp-88_smtp-account).
+        label: Plugin/config label for this relation (e.g. plugin-notifications-88).
+        group_id: OpenSearch config id for the recipient group (e.g. smtp-88_recipients).
+        channel_id: OpenSearch config id for the email channel (e.g. smtp-88_email-channel).
+        transport_security: SMTP transport security (none, start_tls, tls).
+    """
+
+    sender_email: str
+    smtp_account_id: str
+    label: str
+    group_id: str
+    channel_id: str
+    transport_security: TransportSecurity
+
+
+class NotificationsManager(BaseManager):
+    """Notifications plugin API client using OpenSearchDistribution request."""
+
+    def __init__(self, state: ClusterState, workload: BaseWorkload):
+        """Creates the notifications manager class."""
+        super().__init__(state, workload)
+        self.name = "notifications_manager"
+
+    @staticmethod
+    def label(relation_id: int) -> str:
+        """Return label for this relation.
+
+        Args:
+            relation_id: relation id
+
+        Returns:
+            relation label
+        """
+        return f"{SMTP_SECRET_LABEL}-{relation_id}"
+
+    @staticmethod
+    def recipient_group_id(smtp_account_id: str) -> str:
+        """Return recipient group id for this relation.
+
+        The group ids use the relation base (e.g. smtp-88).
+        Removes _smtp-account suffix, if present.
+
+        Args:
+            smtp_account_id: smtp account config id (e.g. smtp-88_smtp-account)
+
+        Returns:
+            recipient group id (e.g. smtp-88_recipients)
+        """
+        base = smtp_account_id.removesuffix("_smtp-account") or smtp_account_id
+        return f"{base}_recipients"
+
+    @staticmethod
+    def email_channel_id(smtp_account_id: str) -> str:
+        """Return email channel id for this relation.
+
+        The channel ids use the relation base (e.g. smtp-88).
+        Strips _smtp-account suffix, if present.
+
+        Args:
+            smtp_account_id: smtp account config id (e.g. smtp-88_smtp-account)
+
+        Returns:
+            email channel id (e.g. smtp-88_email-channel)
+        """
+        base = smtp_account_id.removesuffix("_smtp-account") or smtp_account_id
+        return f"{base}_email-channel"
+
+    @staticmethod
+    def smtp_account_id_from_relation(relation_id: int) -> str:
+        """Return smtp account config id for this relation.
+
+        Config identity is relation-based with smtp-account suffix, e.g. smtp-88_smtp-account.
+
+        Args:
+            relation_id: Juju relation id
+
+        Returns:
+            smtp account config id
+        """
+        return f"smtp-{relation_id}_smtp-account"
+
+    def get_smtp_config(self, parameters: SmtpRelationData, relation_id: int) -> SmtpConfig:
+        """Derive SMTP-related config IDs and normalized values from relation data.
+
+        Args:
+            parameters: SMTP relation data from the smtp-integrator.
+            relation_id: ID of the relation.
+
+        Returns:
+            SmtpConfig with sender_email, smtp_account_id, label, group_id,
+            channel_id, and transport_security.
+        """
+        sender_email = str(parameters.smtp_sender)
+        smtp_account_id = self.smtp_account_id_from_relation(relation_id)
+        label = self.label(relation_id)
+        group_id = self.recipient_group_id(smtp_account_id)
+        channel_id = self.email_channel_id(smtp_account_id)
+        ts = parameters.transport_security
+        raw_ts = ts.value if hasattr(ts, "value") else ts
+        transport_security = TransportSecurity(str(raw_ts).strip().lower())
+        return SmtpConfig(
+            sender_email=sender_email,
+            smtp_account_id=smtp_account_id,
+            label=label,
+            group_id=group_id,
+            channel_id=channel_id,
+            transport_security=transport_security,
+        )
+
+    def put_smtp_sender(
+        self,
+        *,
+        smtp_account_id: str,
+        host: str,
+        port: int,
+        transport_security: TransportSecurity,
+        from_address: str,
+        description: str = "",
+    ) -> None:
+        """Put smtp account configuration.
+
+        Args:
+            smtp_account_id: the id of the smtp account config
+            host: the smtp host
+            port: the smtp port
+            transport_security: security protocol to use for the outgoing SMTP relay
+            from_address: the smtp address
+            description: the smtp description
+        """
+        method = transport_security.api_method()
+        config = {
+            "name": smtp_account_id,
+            "description": description or f"SMTP sender: ({smtp_account_id})",
+            "config_type": "smtp_account",
+            "smtp_account": {
+                "host": host,
+                "port": int(port),
+                "method": method,
+                "from_address": from_address,
+            },
+        }
+        self._create_or_update_config(
+            config_id=smtp_account_id, name=smtp_account_id, config=config
+        )
+
+    def put_email_group(
+        self,
+        *,
+        group_id: str,
+        recipients: Iterable[str],
+        description: str = "",
+    ) -> None:
+        """Put email group configuration.
+
+        Args:
+            group_id: the id of the email group
+            recipients: the email recipients
+            description: the email description
+        """
+        config = {
+            "name": group_id,
+            "description": description or f"Email group managed by ({group_id})",
+            "config_type": "email_group",
+            "email_group": {
+                "recipient_list": [{"recipient": r} for r in recipients],
+            },
+        }
+        self._create_or_update_config(config_id=group_id, name=group_id, config=config)
+
+    def put_email_channel(
+        self,
+        *,
+        channel_id: str,
+        smtp_account_id: str,
+        email_group_ids: list[str],
+        fallback_recipients: Iterable[str] | None = None,
+        description: str = "",
+    ) -> None:
+        """Put email channel configuration.
+
+        Args:
+            channel_id: the id of the email channel
+            smtp_account_id: the id of the smtp account config (email_account_id in API)
+            email_group_ids: the email group ids
+            fallback_recipients: the email recipients
+            description: the email description
+        """
+        config = {
+            "name": channel_id,
+            "description": description or f"Email channel: ({channel_id})",
+            "config_type": "email",
+            "email": {
+                "email_account_id": smtp_account_id,
+                "recipient_list": [{"recipient": r} for r in (fallback_recipients or [])],
+                "email_group_id_list": list(email_group_ids),
+            },
+        }
+        self._create_or_update_config(config_id=channel_id, name=channel_id, config=config)
+
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
+    def delete_config(self, config_id: str) -> None:
+        """Delete config by id.
+
+        404 (config already gone) is treated as success.
+
+        Args:
+            config_id: Notification Config ID
+        """
+        try:
+            self.opensearch_client.request(
+                "DELETE", f"/_plugins/_notifications/configs/{config_id}"
+            )
+        except OpenSearchHttpError as exc:
+            code = getattr(exc, "response_code", None)
+            if code == 404:
+                return
+            raise
+
+    def _create_or_update_config(
+        self, *, config_id: str, name: str, config: dict[str, object]
+    ) -> None:
+        """Create config if missing, otherwise update.
+
+        Args:
+            config_id: Notification Config ID
+            name: Notification Name
+            config: Notification Config
+        """
+        try:
+            if self.config_exists(config_id):
+                self._update_config(config_id=config_id, config=config)
+            else:
+                self._create_config(config_id=config_id, name=name, config=config)
+        except OpenSearchHttpError as exc:
+            raise NotificationsClientError(
+                f"Failed notifications config_id={config_id}: {exc}"
+            ) from exc
+
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
+    def config_exists(self, config_id: str) -> bool:
+        """Check if config exists.
+
+        Args:
+            config_id: Notification Config ID
+
+        Returns:
+            True if config exists, False if 404.
+        """
+        try:
+            self.opensearch_client.request("GET", f"/_plugins/_notifications/configs/{config_id}")
+            return True
+        except OpenSearchHttpError as exc:
+            code = getattr(exc, "response_code", None)
+            if code == 404:
+                return False
+            raise
+
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
+    def _create_config(self, *, config_id: str, name: str, config: dict[str, object]) -> None:
+        """Create notification config.
+
+        Args:
+            config_id: Notification Config ID
+            name: Notification Name
+            config: Notification Config
+        """
+        payload = {"config_id": config_id, "name": name, "config": config}
+        self.opensearch_client.request(
+            "POST", "/_plugins/_notifications/configs/", payload=payload
+        )
+
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
+    def _update_config(self, *, config_id: str, config: dict[str, object]) -> None:
+        """Update notification config.
+
+        Args:
+            config_id: Notification Config ID
+            config: Notification Config
+        """
+        payload = {"config": config}
+        self.opensearch_client.request(
+            "PUT", f"/_plugins/_notifications/configs/{config_id}", payload=payload
+        )

--- a/opensearch_single_kernel/managers/notification.py
+++ b/opensearch_single_kernel/managers/notification.py
@@ -12,58 +12,19 @@ This client wraps OpenSearchDistribution.request() to manage notifications confi
 from __future__ import annotations
 
 from collections.abc import Iterable
-from dataclasses import dataclass
-from enum import Enum
 
-from tenacity import retry, stop_after_attempt, wait_fixed
-
-from opensearch_single_kernel.common.constants import SMTP_SECRET_LABEL
-from opensearch_single_kernel.common.exceptions import OpenSearchHttpError
+from opensearch_single_kernel.common.constants import (
+    SMTP_SECRET_LABEL,
+    SmtpTransportSecurity,
+)
+from opensearch_single_kernel.common.exceptions import (
+    OpenSearchSmtpMissingParametersError,
+)
+from opensearch_single_kernel.core.models import SmtpConfig
 from opensearch_single_kernel.core.state import ClusterState
 from opensearch_single_kernel.lib.charms.smtp_integrator.v0.smtp import SmtpRelationData
 from opensearch_single_kernel.managers.base import BaseManager
 from opensearch_single_kernel.workload.base import BaseWorkload
-
-
-class NotificationsClientError(RuntimeError):
-    """Raises when Notifications API operations fail."""
-
-
-class TransportSecurity(str, Enum):
-    """SMTP transport security protocol.
-
-    Enum values match relation data (smtp-integrator). api_method() maps to
-    OpenSearch Notifications API strings (start_tls, ssl).
-    """
-
-    NONE = "none"
-    STARTTLS = "starttls"
-    TLS = "tls"
-
-    def api_method(self) -> str:
-        """Return the OpenSearch Notifications API method string."""
-        return {"none": "none", "starttls": "start_tls", "tls": "ssl"}[self.value]
-
-
-@dataclass(frozen=True)
-class SmtpConfig:
-    """SMTP-related config derived from relation data.
-
-    Attributes:
-        sender_email: From-address for the SMTP sender (relation smtp_sender).
-        smtp_account_id: OpenSearch config id for the SMTP account (e.g. smtp-88_smtp-account).
-        label: Plugin/config label for this relation (e.g. plugin-notifications-88).
-        group_id: OpenSearch config id for the recipient group (e.g. smtp-88_recipients).
-        channel_id: OpenSearch config id for the email channel (e.g. smtp-88_email-channel).
-        transport_security: SMTP transport security (none, start_tls, tls).
-    """
-
-    sender_email: str
-    smtp_account_id: str
-    label: str
-    group_id: str
-    channel_id: str
-    transport_security: TransportSecurity
 
 
 class NotificationsManager(BaseManager):
@@ -132,7 +93,7 @@ class NotificationsManager(BaseManager):
         """
         return f"smtp-{relation_id}_smtp-account"
 
-    def get_smtp_config(self, parameters: SmtpRelationData, relation_id: int) -> SmtpConfig:
+    def get_smtp_config(self, smtp_data: SmtpRelationData, relation_id: int) -> SmtpConfig:
         """Derive SMTP-related config IDs and normalized values from relation data.
 
         Args:
@@ -143,14 +104,31 @@ class NotificationsManager(BaseManager):
             SmtpConfig with sender_email, smtp_account_id, label, group_id,
             channel_id, and transport_security.
         """
-        sender_email = str(parameters.smtp_sender)
+        missing = []
+        if not smtp_data.smtp_sender:
+            missing.append("smtp_sender")
+        if not smtp_data.host:
+            missing.append("host")
+        if not smtp_data.port:
+            missing.append("port")
+        if not smtp_data.transport_security:
+            missing.append("transport_security")
+        if smtp_data.auth_type != "none":
+            if not smtp_data.user:
+                missing.append("user")
+            if not smtp_data.password:
+                missing.append("password")
+        if missing:
+            raise OpenSearchSmtpMissingParametersError(missing)
+
+        sender_email = str(smtp_data.smtp_sender)
         smtp_account_id = self.smtp_account_id_from_relation(relation_id)
         label = self.label(relation_id)
         group_id = self.recipient_group_id(smtp_account_id)
         channel_id = self.email_channel_id(smtp_account_id)
-        ts = parameters.transport_security
+        ts = smtp_data.transport_security
         raw_ts = ts.value if hasattr(ts, "value") else ts
-        transport_security = TransportSecurity(str(raw_ts).strip().lower())
+        transport_security = SmtpTransportSecurity(str(raw_ts).strip().lower())
         return SmtpConfig(
             sender_email=sender_email,
             smtp_account_id=smtp_account_id,
@@ -166,7 +144,7 @@ class NotificationsManager(BaseManager):
         smtp_account_id: str,
         host: str,
         port: int,
-        transport_security: TransportSecurity,
+        transport_security: SmtpTransportSecurity,
         from_address: str,
         description: str = "",
     ) -> None:
@@ -192,7 +170,7 @@ class NotificationsManager(BaseManager):
                 "from_address": from_address,
             },
         }
-        self._create_or_update_config(
+        self.opensearch_client.create_or_update_notification_config(
             config_id=smtp_account_id, name=smtp_account_id, config=config
         )
 
@@ -218,7 +196,9 @@ class NotificationsManager(BaseManager):
                 "recipient_list": [{"recipient": r} for r in recipients],
             },
         }
-        self._create_or_update_config(config_id=group_id, name=group_id, config=config)
+        self.opensearch_client.create_or_update_notification_config(
+            config_id=group_id, name=group_id, config=config
+        )
 
     def put_email_channel(
         self,
@@ -248,89 +228,6 @@ class NotificationsManager(BaseManager):
                 "email_group_id_list": list(email_group_ids),
             },
         }
-        self._create_or_update_config(config_id=channel_id, name=channel_id, config=config)
-
-    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
-    def delete_config(self, config_id: str) -> None:
-        """Delete config by id.
-
-        404 (config already gone) is treated as success.
-
-        Args:
-            config_id: Notification Config ID
-        """
-        try:
-            self.opensearch_client.request(
-                "DELETE", f"/_plugins/_notifications/configs/{config_id}"
-            )
-        except OpenSearchHttpError as exc:
-            code = getattr(exc, "response_code", None)
-            if code == 404:
-                return
-            raise
-
-    def _create_or_update_config(
-        self, *, config_id: str, name: str, config: dict[str, object]
-    ) -> None:
-        """Create config if missing, otherwise update.
-
-        Args:
-            config_id: Notification Config ID
-            name: Notification Name
-            config: Notification Config
-        """
-        try:
-            if self.config_exists(config_id):
-                self._update_config(config_id=config_id, config=config)
-            else:
-                self._create_config(config_id=config_id, name=name, config=config)
-        except OpenSearchHttpError as exc:
-            raise NotificationsClientError(
-                f"Failed notifications config_id={config_id}: {exc}"
-            ) from exc
-
-    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
-    def config_exists(self, config_id: str) -> bool:
-        """Check if config exists.
-
-        Args:
-            config_id: Notification Config ID
-
-        Returns:
-            True if config exists, False if 404.
-        """
-        try:
-            self.opensearch_client.request("GET", f"/_plugins/_notifications/configs/{config_id}")
-            return True
-        except OpenSearchHttpError as exc:
-            code = getattr(exc, "response_code", None)
-            if code == 404:
-                return False
-            raise
-
-    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
-    def _create_config(self, *, config_id: str, name: str, config: dict[str, object]) -> None:
-        """Create notification config.
-
-        Args:
-            config_id: Notification Config ID
-            name: Notification Name
-            config: Notification Config
-        """
-        payload = {"config_id": config_id, "name": name, "config": config}
-        self.opensearch_client.request(
-            "POST", "/_plugins/_notifications/configs/", payload=payload
-        )
-
-    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
-    def _update_config(self, *, config_id: str, config: dict[str, object]) -> None:
-        """Update notification config.
-
-        Args:
-            config_id: Notification Config ID
-            config: Notification Config
-        """
-        payload = {"config": config}
-        self.opensearch_client.request(
-            "PUT", f"/_plugins/_notifications/configs/{config_id}", payload=payload
+        self.opensearch_client.create_or_update_notification_config(
+            config_id=channel_id, name=channel_id, config=config
         )

--- a/opensearch_single_kernel/managers/notification.py
+++ b/opensearch_single_kernel/managers/notification.py
@@ -170,7 +170,7 @@ class NotificationsManager(BaseManager):
                 "from_address": from_address,
             },
         }
-        self.opensearch_client.create_or_update_notification_config(
+        self.opensearch_client.put_notification_config(
             config_id=smtp_account_id, name=smtp_account_id, config=config
         )
 
@@ -196,7 +196,7 @@ class NotificationsManager(BaseManager):
                 "recipient_list": [{"recipient": r} for r in recipients],
             },
         }
-        self.opensearch_client.create_or_update_notification_config(
+        self.opensearch_client.put_notification_config(
             config_id=group_id, name=group_id, config=config
         )
 
@@ -228,6 +228,6 @@ class NotificationsManager(BaseManager):
                 "email_group_id_list": list(email_group_ids),
             },
         }
-        self.opensearch_client.create_or_update_notification_config(
+        self.opensearch_client.put_notification_config(
             config_id=channel_id, name=channel_id, config=config
         )

--- a/opensearch_single_kernel/managers/notification.py
+++ b/opensearch_single_kernel/managers/notification.py
@@ -1,12 +1,9 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""OpenSearch Notifications plugin API client (configs CRUD).
+"""OpenSearch Notifications plugin manager.
 
-This client wraps OpenSearchDistribution.request() to manage notifications configs:
-- smtp sender (config_type: smtp_account)
-- email group (config_type: email_group)
-- email channel (config_type: email)
+This module is responsible of building and / or passing SMTP configs into the OpenSearch client.
 """
 
 from __future__ import annotations
@@ -28,7 +25,7 @@ from opensearch_single_kernel.workload.base import BaseWorkload
 
 
 class NotificationsManager(BaseManager):
-    """Notifications plugin API client using OpenSearchDistribution request."""
+    """OpenSearch Notifications plugin manager."""
 
     def __init__(self, state: ClusterState, workload: BaseWorkload):
         """Creates the notifications manager class."""

--- a/opensearch_single_kernel/managers/plugin.py
+++ b/opensearch_single_kernel/managers/plugin.py
@@ -1,0 +1,96 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Implements the plugin manager class.
+
+This module manages each plugin's lifecycle. It is responsible to install, configure and
+upgrade of each of the plugins.
+
+This class is instantiated at the operator level and is called at every relevant event:
+config-changed, upgrade, s3-credentials-changed, etc.
+"""
+
+import json
+import logging
+
+from ops import ModelError, SecretNotFoundError
+
+from opensearch_single_kernel.common.constants import Scope
+from opensearch_single_kernel.core.models import PluginConfigInfo
+from opensearch_single_kernel.core.state import ClusterState
+from opensearch_single_kernel.managers.base import BaseManager
+from opensearch_single_kernel.workload.base import BaseWorkload
+
+logger = logging.getLogger(__name__)
+
+
+class PluginManager(BaseManager):
+    """Manager to persist OpenSearch plugin configuration information"""
+
+    def __init__(self, state: ClusterState, workload: BaseWorkload):
+        """Creates the plugin manager class."""
+        super().__init__(state, workload)
+        self.name = "plugin_manager"
+
+    def put_plugin_config(
+        self,
+        scope: Scope,
+        label: str,
+        secret_id: str | None = None,
+        relation_name: str | None = None,
+        cleanup: dict[str, list[str]] | None = None,
+    ) -> None:
+        """Adds plugin configuration information to peer relation data"""
+        state = self.state.application if scope == Scope.APP else self.state.server
+        plugins = state.plugin_config_info
+        plugin_config = plugins.get(label) or PluginConfigInfo()
+        plugin_config.relation_name = relation_name
+        plugin_config.secret_id = secret_id
+        if cleanup:
+            plugin_config.add_cleanup_items(cleanup)
+        plugins[label] = plugin_config
+        state.plugin_config_info = plugins
+
+    def remove_plugin_config(self, scope: Scope, label: str) -> None:
+        """Removes plugin configuration information from peer relation data"""
+        state = self.state.application if scope == Scope.APP else self.state.server
+        plugins = state.plugin_config_info
+        if label in plugins:
+            del plugins[label]
+        state.plugin_config_info = plugins
+
+    def store_plugin_secret(
+        self,
+        *,
+        content: dict,
+        label: str,
+        relation_name: str | None = None,
+    ) -> None:
+        """Create/update app-scoped plugin secret and store id in peers data.
+
+        Args:
+            content: dictionary of the secret payload
+            label: label of the secret to store
+            relation_name: name of the relation from which the secret content came
+        """
+        self.state.secrets.put(Scope.APP, label, json.dumps(content))
+        secret_id = self.state.secrets.get_secret_id(Scope.APP, label)
+        if not secret_id:
+            logger.error("Could not create secret with label: %s", label)
+        self.put_plugin_config(
+            Scope.APP, label=label, secret_id=secret_id, relation_name=relation_name
+        )
+
+    def remove_plugin_secret(self, label: str) -> None:
+        """Delete app-scoped plugin secret and remove id from peers data.
+
+        Args:
+            label: label of the secret to remove
+        """
+        try:
+            self.state.secrets.delete(Scope.APP, label)
+        except SecretNotFoundError:
+            logger.error("Can't find secret '%s'", label)
+        except ModelError as e:
+            logger.error("Cannot delete secret %s: %s", label, e)
+        self.remove_plugin_config(Scope.APP, label)

--- a/opensearch_single_kernel/managers/plugin.py
+++ b/opensearch_single_kernel/managers/plugin.py
@@ -16,7 +16,7 @@ import logging
 from ops import ModelError, SecretNotFoundError
 
 from opensearch_single_kernel.common.constants import Scope
-from opensearch_single_kernel.core.models import PluginConfigInfo
+from opensearch_single_kernel.core.models import PluginConfigInfo, SmtpConfig
 from opensearch_single_kernel.core.state import ClusterState
 from opensearch_single_kernel.managers.base import BaseManager
 from opensearch_single_kernel.workload.base import BaseWorkload
@@ -50,6 +50,31 @@ class PluginManager(BaseManager):
             plugin_config.add_cleanup_items(cleanup)
         plugins[label] = plugin_config
         state.plugin_config_info = plugins
+
+    def put_notifications_plugin_smtp_config(
+        self,
+        config: SmtpConfig,
+        credentials: dict[str, str],
+        store_secret: bool,
+        relation_name: str,
+    ) -> None:
+        """Add a notifications plugin SMTP config with credentials and secret (if store_secret)."""
+        cleanup = {
+            "keys": list(credentials.keys()),
+            "smtp_account_id": [config.smtp_account_id],
+        }
+        self.put_plugin_config(scope=Scope.UNIT, label=config.label, cleanup=cleanup)
+
+        if store_secret:
+            # leader stores secret for subclusters for per relation
+            self.store_plugin_secret(
+                content={
+                    "keys": credentials,
+                    "smtp_account_id": cleanup["smtp_account_id"],
+                },
+                label=config.label,
+                relation_name=relation_name,
+            )
 
     def remove_plugin_config(self, scope: Scope, label: str) -> None:
         """Removes plugin configuration information from peer relation data"""

--- a/opensearch_single_kernel/utils/helpers.py
+++ b/opensearch_single_kernel/utils/helpers.py
@@ -3,12 +3,16 @@
 # See LICENSE file for licensing details.
 
 """A set of helpers functions."""
+
 import base64
+import json
+import logging
 import math
 import re
 import secrets
 import string
 from datetime import datetime
+from typing import Iterable
 
 import bcrypt
 from cryptography import x509
@@ -20,6 +24,8 @@ from opensearch_single_kernel.common.constants import (
 )
 from opensearch_single_kernel.common.exceptions import OpenSearchCmdError
 from opensearch_single_kernel.core.models import App, PeerClusterConfig
+
+logger = logging.getLogger(__name__)
 
 
 def format_unit_name(unit: Unit | str, app: App) -> str:
@@ -120,3 +126,34 @@ def parse_tls_file(raw_content: str) -> bytes:
             raw_content,
         ).encode("utf-8")
     return base64.b64decode(raw_content)
+
+
+def diff(desired: Iterable[str], current: Iterable[str]) -> tuple[set[str], set[str]]:
+    """Returns diff needed to turn current list into desired list"""
+    desired_labels = set(desired)
+    current_labels = set(current)
+
+    add = desired_labels - current_labels
+    remove = current_labels - desired_labels
+    return add, remove
+
+
+def decode_plugin_secret_content(content: dict, label: str) -> dict[str, str] | None:
+    """Decodes JSON payload from plugin secret
+
+    Args:
+        content: dictionary of the secret content
+        label: label of the secfet
+
+    Returns:
+        A decoded dictionary if successful, else None
+    """
+    if not (raw := content.get(label)):
+        logger.warning("Key '%s' not found in secret content", label)
+        return None
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        logger.error("Malformed JSON in secret %s: %s", label, e)
+        return None

--- a/opensearch_single_kernel/workload/base.py
+++ b/opensearch_single_kernel/workload/base.py
@@ -79,6 +79,11 @@ class Paths:
         return self.conf / "opensearch.yml"
 
     @property
+    def opensearch_keystore(self) -> PathProtocol:
+        """Return path to the opensearch keystore."""
+        return self.conf / "opensearch.keystore"
+
+    @property
     def data(self) -> PathProtocol:
         """Return path to the data snap directory."""
         return self.snap_common / OpenSearchPaths.DATA.val

--- a/poetry.lock
+++ b/poetry.lock
@@ -61,26 +61,6 @@ files = [
 ]
 
 [[package]]
-name = "anyio"
-version = "4.12.1"
-description = "High-level concurrency and networking framework on top of asyncio or Trio"
-optional = false
-python-versions = ">=3.9"
-groups = ["integration"]
-files = [
-    {file = "anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"},
-    {file = "anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703"},
-]
-
-[package.dependencies]
-exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
-idna = ">=2.8"
-typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
-
-[package.extras]
-trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 description = "Annotate AST trees with source code positions"
@@ -1133,161 +1113,6 @@ testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "cry
 urllib3 = ["packaging", "urllib3"]
 
 [[package]]
-name = "greenlet"
-version = "3.3.1"
-description = "Lightweight in-process concurrent programming"
-optional = false
-python-versions = ">=3.10"
-groups = ["integration"]
-files = [
-    {file = "greenlet-3.3.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:04bee4775f40ecefcdaa9d115ab44736cd4b9c5fba733575bfe9379419582e13"},
-    {file = "greenlet-3.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e1457f4fed12a50e427988a07f0f9df53cf0ee8da23fab16e6732c2ec909d4"},
-    {file = "greenlet-3.3.1-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:070472cd156f0656f86f92e954591644e158fd65aa415ffbe2d44ca77656a8f5"},
-    {file = "greenlet-3.3.1-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1108b61b06b5224656121c3c8ee8876161c491cbe74e5c519e0634c837cf93d5"},
-    {file = "greenlet-3.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a300354f27dd86bae5fbf7002e6dd2b3255cd372e9242c933faf5e859b703fe"},
-    {file = "greenlet-3.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e84b51cbebf9ae573b5fbd15df88887815e3253fc000a7d0ff95170e8f7e9729"},
-    {file = "greenlet-3.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0093bd1a06d899892427217f0ff2a3c8f306182b8c754336d32e2d587c131b4"},
-    {file = "greenlet-3.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:7932f5f57609b6a3b82cc11877709aa7a98e3308983ed93552a1c377069b20c8"},
-    {file = "greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c"},
-    {file = "greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd"},
-    {file = "greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5"},
-    {file = "greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f"},
-    {file = "greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2"},
-    {file = "greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9"},
-    {file = "greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f"},
-    {file = "greenlet-3.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:32e4ca9777c5addcbf42ff3915d99030d8e00173a56f80001fb3875998fe410b"},
-    {file = "greenlet-3.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:da19609432f353fed186cc1b85e9440db93d489f198b4bdf42ae19cc9d9ac9b4"},
-    {file = "greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975"},
-    {file = "greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36"},
-    {file = "greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba"},
-    {file = "greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca"},
-    {file = "greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336"},
-    {file = "greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1"},
-    {file = "greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149"},
-    {file = "greenlet-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:cc98b9c4e4870fa983436afa999d4eb16b12872fab7071423d5262fa7120d57a"},
-    {file = "greenlet-3.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:bfb2d1763d777de5ee495c85309460f6fd8146e50ec9d0ae0183dbf6f0a829d1"},
-    {file = "greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3"},
-    {file = "greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac"},
-    {file = "greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd"},
-    {file = "greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e"},
-    {file = "greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3"},
-    {file = "greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951"},
-    {file = "greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2"},
-    {file = "greenlet-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:27289986f4e5b0edec7b5a91063c109f0276abb09a7e9bdab08437525977c946"},
-    {file = "greenlet-3.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:2f080e028001c5273e0b42690eaf359aeef9cb1389da0f171ea51a5dc3c7608d"},
-    {file = "greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5"},
-    {file = "greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b"},
-    {file = "greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e"},
-    {file = "greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d"},
-    {file = "greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f"},
-    {file = "greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683"},
-    {file = "greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1"},
-    {file = "greenlet-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:96aff77af063b607f2489473484e39a0bbae730f2ea90c9e5606c9b73c44174a"},
-    {file = "greenlet-3.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:b066e8b50e28b503f604fa538adc764a638b38cf8e81e025011d26e8a627fa79"},
-    {file = "greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242"},
-    {file = "greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774"},
-    {file = "greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97"},
-    {file = "greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab"},
-    {file = "greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2"},
-    {file = "greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53"},
-    {file = "greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249"},
-    {file = "greenlet-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:301860987846c24cb8964bdec0e31a96ad4a2a801b41b4ef40963c1b44f33451"},
-    {file = "greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98"},
-]
-
-[package.extras]
-docs = ["Sphinx", "furo"]
-test = ["objgraph", "psutil", "setuptools"]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
-    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
-]
-
-[[package]]
-name = "h2"
-version = "4.3.0"
-description = "Pure-Python HTTP/2 protocol implementation"
-optional = false
-python-versions = ">=3.9"
-groups = ["integration"]
-files = [
-    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
-    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
-]
-
-[package.dependencies]
-hpack = ">=4.1,<5"
-hyperframe = ">=6.1,<7"
-
-[[package]]
-name = "hpack"
-version = "4.1.0"
-description = "Pure-Python HPACK header encoding"
-optional = false
-python-versions = ">=3.9"
-groups = ["integration"]
-files = [
-    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
-    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-description = "A minimal low-level HTTP client."
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
-    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
-]
-
-[package.dependencies]
-certifi = "*"
-h11 = ">=0.16"
-
-[package.extras]
-asyncio = ["anyio (>=4.0,<5.0)"]
-http2 = ["h2 (>=3,<5)"]
-socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<1.0)"]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-description = "The next generation HTTP client."
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
-    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
-]
-
-[package.dependencies]
-anyio = "*"
-certifi = "*"
-h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
-httpcore = "==1.*"
-idna = "*"
-
-[package.extras]
-brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
-cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
-http2 = ["h2 (>=3,<5)"]
-socks = ["socksio (==1.*)"]
-zstd = ["zstandard (>=0.18.0)"]
-
-[[package]]
 name = "hvac"
 version = "2.4.0"
 description = "HashiCorp Vault API client"
@@ -1304,18 +1129,6 @@ requests = ">=2.27.1,<3.0.0"
 
 [package.extras]
 parser = ["pyhcl (>=0.4.4,<0.5.0)"]
-
-[[package]]
-name = "hyperframe"
-version = "6.1.0"
-description = "Pure-Python HTTP/2 framing"
-optional = false
-python-versions = ">=3.9"
-groups = ["integration"]
-files = [
-    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
-    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
-]
 
 [[package]]
 name = "identify"
@@ -1625,38 +1438,6 @@ websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.dev0 || >=0.43.dev0"
 adal = ["adal (>=1.0.2)"]
 
 [[package]]
-name = "lightkube"
-version = "0.19.1"
-description = "Lightweight kubernetes client library"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "lightkube-0.19.1-py3-none-any.whl", hash = "sha256:49fef08a1c7aa42082820111ffd5dbbaf78f54c99385810690fc9d94eef5c80d"},
-    {file = "lightkube-0.19.1.tar.gz", hash = "sha256:4c8526068024c194c02fbc0ca6021922feb4b1b9d741d330129f873b27e0fe97"},
-]
-
-[package.dependencies]
-httpx = {version = ">=0.28.1,<1.0.0", extras = ["http2"]}
-lightkube-models = ">=1.15.12.0"
-pyyaml = "*"
-
-[package.extras]
-jinja-templates = ["jinja2"]
-
-[[package]]
-name = "lightkube-models"
-version = "1.35.0.8"
-description = "Models and Resources for lightkube module"
-optional = false
-python-versions = ">=3.9"
-groups = ["integration"]
-files = [
-    {file = "lightkube_models-1.35.0.8-py3-none-any.whl", hash = "sha256:d01fce42f96baf47a77a571bff59d6a513e96ae043fc03cfaaaaf79c609c4441"},
-    {file = "lightkube_models-1.35.0.8.tar.gz", hash = "sha256:dbc624596a7d94e6c43c5deda972be964202e0e8f26e2ab8e61d589d710b5e22"},
-]
-
-[[package]]
 name = "macaroonbakery"
 version = "1.3.4"
 description = "A Python library port for bakery, higher level operation to work with macaroons"
@@ -1904,29 +1685,6 @@ files = [
 ]
 
 [[package]]
-name = "oauth_tools"
-version = "0.1.2"
-description = "A collection of tools useful for testing oauth interface"
-optional = false
-python-versions = ">=3.7"
-groups = ["integration"]
-files = []
-develop = false
-
-[package.dependencies]
-httpx = "0.28.1"
-lightkube = "*"
-pytest = "*"
-pytest_operator = "*"
-pytest-playwright = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/canonical/iam-bundle"
-reference = "921d113325eed156e5b54f97c42e6c50810180c0"
-resolved_reference = "921d113325eed156e5b54f97c42e6c50810180c0"
-
-[[package]]
 name = "oauthlib"
 version = "3.3.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -2158,28 +1916,6 @@ files = [
 docs = ["furo (>=2025.9.25)", "proselint (>=0.14)", "sphinx (>=8.2.3)", "sphinx-autodoc-typehints (>=3.2)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.4.2)", "pytest-cov (>=7)", "pytest-mock (>=3.15.1)"]
 type = ["mypy (>=1.18.2)"]
-
-[[package]]
-name = "playwright"
-version = "1.58.0"
-description = "A high-level API to automate web browsers"
-optional = false
-python-versions = ">=3.9"
-groups = ["integration"]
-files = [
-    {file = "playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606"},
-    {file = "playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71"},
-    {file = "playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117"},
-    {file = "playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b"},
-    {file = "playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa"},
-    {file = "playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99"},
-    {file = "playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8"},
-    {file = "playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b"},
-]
-
-[package.dependencies]
-greenlet = ">=3.1.1,<4.0.0"
-pyee = ">=13,<14"
 
 [[package]]
 name = "pluggy"
@@ -2518,24 +2254,6 @@ snowballstemmer = ">=2.2.0"
 toml = ["tomli (>=1.2.3) ; python_version < \"3.11\""]
 
 [[package]]
-name = "pyee"
-version = "13.0.1"
-description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228"},
-    {file = "pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8"},
-]
-
-[package.dependencies]
-typing-extensions = "*"
-
-[package.extras]
-dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "mypy", "pytest", "pytest-asyncio ; python_version >= \"3.4\"", "pytest-trio ; python_version >= \"3.7\"", "sphinx", "toml", "tox", "trio", "trio ; python_version > \"3.6\"", "trio-typing ; python_version > \"3.6\"", "twine", "twisted", "validate-pyproject[all]"]
-
-[[package]]
 name = "pyflakes"
 version = "3.2.0"
 description = "passive checker of Python programs"
@@ -2718,25 +2436,6 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
-name = "pytest-base-url"
-version = "2.1.0"
-description = "pytest plugin for URL based testing"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6"},
-    {file = "pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45"},
-]
-
-[package.dependencies]
-pytest = ">=7.0.0"
-requests = ">=2.9"
-
-[package.extras]
-test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "pytest-localserver (>=0.7.1)", "tox (>=3.24.5)"]
-
-[[package]]
 name = "pytest-microceph"
 version = "0.1.0"
 description = ""
@@ -2796,24 +2495,6 @@ pytest-asyncio = "<0.23"
 pyyaml = "*"
 
 [[package]]
-name = "pytest-playwright"
-version = "0.7.2"
-description = "A pytest wrapper with fixtures for Playwright to automate web browsers"
-optional = false
-python-versions = ">=3.10"
-groups = ["integration"]
-files = [
-    {file = "pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38"},
-    {file = "pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770"},
-]
-
-[package.dependencies]
-playwright = ">=1.18"
-pytest = ">=6.2.4,<10.0.0"
-pytest-base-url = ">=1.0.0,<3.0.0"
-python-slugify = ">=6.0.0,<9.0.0"
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2827,24 +2508,6 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
-
-[[package]]
-name = "python-slugify"
-version = "8.0.4"
-description = "A Python slugify application that also handles Unicode"
-optional = false
-python-versions = ">=3.7"
-groups = ["integration"]
-files = [
-    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
-    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
-]
-
-[package.dependencies]
-text-unidecode = ">=1.3"
-
-[package.extras]
-unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "pytokens"
@@ -3411,18 +3074,6 @@ doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
-name = "text-unidecode"
-version = "1.3"
-description = "The most basic Text::Unidecode port"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
-    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.3.0"
 description = "A lil' TOML parser"
@@ -3718,4 +3369,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "5b79308e349db6ee0b141247c5740746acaf246fed53251968433d5518a8e5dc"
+content-hash = "ca422b5975dc186e3fd9bdf4c77000b0f24abfe3eb3e436fafc00c64de6c9853"

--- a/poetry.lock
+++ b/poetry.lock
@@ -61,6 +61,26 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+description = "High-level concurrency and networking framework on top of asyncio or Trio"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"},
+    {file = "anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703"},
+]
+
+[package.dependencies]
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
+idna = ">=2.8"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 description = "Annotate AST trees with source code positions"
@@ -926,6 +946,43 @@ files = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["charm-libs"]
+files = [
+    {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
+    {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
+]
+
+[package.extras]
+dev = ["black (>=25.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.17.0)", "mypy (>=1.17)", "pylint (>=3)", "pytest (>=8.4)", "pytest-cov (>=6.2.0)", "quart-trio (>=0.12.0)", "sphinx (>=8.2.0)", "sphinx-rtd-theme (>=3.0.0)", "twine (>=6.1.0)", "wheel (>=0.45.0)"]
+dnssec = ["cryptography (>=45)"]
+doh = ["h2 (>=4.2.0)", "httpcore (>=1.0.0)", "httpx (>=0.28.0)"]
+doq = ["aioquic (>=1.2.0)"]
+idna = ["idna (>=3.10)"]
+trio = ["trio (>=0.30)"]
+wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+description = "A robust email address syntax and deliverability validation library."
+optional = false
+python-versions = ">=3.8"
+groups = ["charm-libs"]
+files = [
+    {file = "email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"},
+    {file = "email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426"},
+]
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+idna = ">=2.0.0"
+
+[[package]]
 name = "events"
 version = "0.5"
 description = "Bringing the elegance of C# EventHandler to Python"
@@ -1076,6 +1133,161 @@ testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "cry
 urllib3 = ["packaging", "urllib3"]
 
 [[package]]
+name = "greenlet"
+version = "3.3.1"
+description = "Lightweight in-process concurrent programming"
+optional = false
+python-versions = ">=3.10"
+groups = ["integration"]
+files = [
+    {file = "greenlet-3.3.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:04bee4775f40ecefcdaa9d115ab44736cd4b9c5fba733575bfe9379419582e13"},
+    {file = "greenlet-3.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e1457f4fed12a50e427988a07f0f9df53cf0ee8da23fab16e6732c2ec909d4"},
+    {file = "greenlet-3.3.1-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:070472cd156f0656f86f92e954591644e158fd65aa415ffbe2d44ca77656a8f5"},
+    {file = "greenlet-3.3.1-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1108b61b06b5224656121c3c8ee8876161c491cbe74e5c519e0634c837cf93d5"},
+    {file = "greenlet-3.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a300354f27dd86bae5fbf7002e6dd2b3255cd372e9242c933faf5e859b703fe"},
+    {file = "greenlet-3.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e84b51cbebf9ae573b5fbd15df88887815e3253fc000a7d0ff95170e8f7e9729"},
+    {file = "greenlet-3.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0093bd1a06d899892427217f0ff2a3c8f306182b8c754336d32e2d587c131b4"},
+    {file = "greenlet-3.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:7932f5f57609b6a3b82cc11877709aa7a98e3308983ed93552a1c377069b20c8"},
+    {file = "greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c"},
+    {file = "greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd"},
+    {file = "greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5"},
+    {file = "greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f"},
+    {file = "greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2"},
+    {file = "greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9"},
+    {file = "greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f"},
+    {file = "greenlet-3.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:32e4ca9777c5addcbf42ff3915d99030d8e00173a56f80001fb3875998fe410b"},
+    {file = "greenlet-3.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:da19609432f353fed186cc1b85e9440db93d489f198b4bdf42ae19cc9d9ac9b4"},
+    {file = "greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975"},
+    {file = "greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36"},
+    {file = "greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba"},
+    {file = "greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca"},
+    {file = "greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336"},
+    {file = "greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1"},
+    {file = "greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149"},
+    {file = "greenlet-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:cc98b9c4e4870fa983436afa999d4eb16b12872fab7071423d5262fa7120d57a"},
+    {file = "greenlet-3.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:bfb2d1763d777de5ee495c85309460f6fd8146e50ec9d0ae0183dbf6f0a829d1"},
+    {file = "greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3"},
+    {file = "greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac"},
+    {file = "greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd"},
+    {file = "greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e"},
+    {file = "greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3"},
+    {file = "greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951"},
+    {file = "greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2"},
+    {file = "greenlet-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:27289986f4e5b0edec7b5a91063c109f0276abb09a7e9bdab08437525977c946"},
+    {file = "greenlet-3.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:2f080e028001c5273e0b42690eaf359aeef9cb1389da0f171ea51a5dc3c7608d"},
+    {file = "greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5"},
+    {file = "greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b"},
+    {file = "greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e"},
+    {file = "greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d"},
+    {file = "greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f"},
+    {file = "greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683"},
+    {file = "greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1"},
+    {file = "greenlet-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:96aff77af063b607f2489473484e39a0bbae730f2ea90c9e5606c9b73c44174a"},
+    {file = "greenlet-3.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:b066e8b50e28b503f604fa538adc764a638b38cf8e81e025011d26e8a627fa79"},
+    {file = "greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242"},
+    {file = "greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774"},
+    {file = "greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97"},
+    {file = "greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab"},
+    {file = "greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2"},
+    {file = "greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53"},
+    {file = "greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249"},
+    {file = "greenlet-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:301860987846c24cb8964bdec0e31a96ad4a2a801b41b4ef40963c1b44f33451"},
+    {file = "greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98"},
+]
+
+[package.extras]
+docs = ["Sphinx", "furo"]
+test = ["objgraph", "psutil", "setuptools"]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+description = "Pure-Python HTTP/2 protocol implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[package.dependencies]
+hpack = ">=4.1,<5"
+hyperframe = ">=6.1,<7"
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+description = "Pure-Python HPACK header encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
 name = "hvac"
 version = "2.4.0"
 description = "HashiCorp Vault API client"
@@ -1092,6 +1304,18 @@ requests = ">=2.27.1,<3.0.0"
 
 [package.extras]
 parser = ["pyhcl (>=0.4.4,<0.5.0)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+description = "Pure-Python HTTP/2 framing"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
+]
 
 [[package]]
 name = "identify"
@@ -1114,7 +1338,7 @@ version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "integration", "unit"]
+groups = ["main", "charm-libs", "integration", "unit"]
 files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
@@ -1401,6 +1625,38 @@ websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.dev0 || >=0.43.dev0"
 adal = ["adal (>=1.0.2)"]
 
 [[package]]
+name = "lightkube"
+version = "0.19.1"
+description = "Lightweight kubernetes client library"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "lightkube-0.19.1-py3-none-any.whl", hash = "sha256:49fef08a1c7aa42082820111ffd5dbbaf78f54c99385810690fc9d94eef5c80d"},
+    {file = "lightkube-0.19.1.tar.gz", hash = "sha256:4c8526068024c194c02fbc0ca6021922feb4b1b9d741d330129f873b27e0fe97"},
+]
+
+[package.dependencies]
+httpx = {version = ">=0.28.1,<1.0.0", extras = ["http2"]}
+lightkube-models = ">=1.15.12.0"
+pyyaml = "*"
+
+[package.extras]
+jinja-templates = ["jinja2"]
+
+[[package]]
+name = "lightkube-models"
+version = "1.35.0.8"
+description = "Models and Resources for lightkube module"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "lightkube_models-1.35.0.8-py3-none-any.whl", hash = "sha256:d01fce42f96baf47a77a571bff59d6a513e96ae043fc03cfaaaaf79c609c4441"},
+    {file = "lightkube_models-1.35.0.8.tar.gz", hash = "sha256:dbc624596a7d94e6c43c5deda972be964202e0e8f26e2ab8e61d589d710b5e22"},
+]
+
+[[package]]
 name = "macaroonbakery"
 version = "1.3.4"
 description = "A Python library port for bakery, higher level operation to work with macaroons"
@@ -1648,6 +1904,29 @@ files = [
 ]
 
 [[package]]
+name = "oauth_tools"
+version = "0.1.2"
+description = "A collection of tools useful for testing oauth interface"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = []
+develop = false
+
+[package.dependencies]
+httpx = "0.28.1"
+lightkube = "*"
+pytest = "*"
+pytest_operator = "*"
+pytest-playwright = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/canonical/iam-bundle"
+reference = "921d113325eed156e5b54f97c42e6c50810180c0"
+resolved_reference = "921d113325eed156e5b54f97c42e6c50810180c0"
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1879,6 +2158,28 @@ files = [
 docs = ["furo (>=2025.9.25)", "proselint (>=0.14)", "sphinx (>=8.2.3)", "sphinx-autodoc-typehints (>=3.2)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.4.2)", "pytest-cov (>=7)", "pytest-mock (>=3.15.1)"]
 type = ["mypy (>=1.18.2)"]
+
+[[package]]
+name = "playwright"
+version = "1.58.0"
+description = "A high-level API to automate web browsers"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606"},
+    {file = "playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71"},
+    {file = "playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117"},
+    {file = "playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b"},
+    {file = "playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa"},
+    {file = "playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99"},
+    {file = "playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8"},
+    {file = "playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b"},
+]
+
+[package.dependencies]
+greenlet = ">=3.1.1,<4.0.0"
+pyee = ">=13,<14"
 
 [[package]]
 name = "pluggy"
@@ -2217,6 +2518,24 @@ snowballstemmer = ">=2.2.0"
 toml = ["tomli (>=1.2.3) ; python_version < \"3.11\""]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228"},
+    {file = "pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "mypy", "pytest", "pytest-asyncio ; python_version >= \"3.4\"", "pytest-trio ; python_version >= \"3.7\"", "sphinx", "toml", "tox", "trio", "trio ; python_version > \"3.6\"", "trio-typing ; python_version > \"3.6\"", "twine", "twisted", "validate-pyproject[all]"]
+
+[[package]]
 name = "pyflakes"
 version = "3.2.0"
 description = "passive checker of Python programs"
@@ -2399,6 +2718,25 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+description = "pytest plugin for URL based testing"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6"},
+    {file = "pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+requests = ">=2.9"
+
+[package.extras]
+test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "pytest-localserver (>=0.7.1)", "tox (>=3.24.5)"]
+
+[[package]]
 name = "pytest-microceph"
 version = "0.1.0"
 description = ""
@@ -2458,6 +2796,24 @@ pytest-asyncio = "<0.23"
 pyyaml = "*"
 
 [[package]]
+name = "pytest-playwright"
+version = "0.7.2"
+description = "A pytest wrapper with fixtures for Playwright to automate web browsers"
+optional = false
+python-versions = ">=3.10"
+groups = ["integration"]
+files = [
+    {file = "pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38"},
+    {file = "pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770"},
+]
+
+[package.dependencies]
+playwright = ">=1.18"
+pytest = ">=6.2.4,<10.0.0"
+pytest-base-url = ">=1.0.0,<3.0.0"
+python-slugify = ">=6.0.0,<9.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2471,6 +2827,24 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+description = "A Python slugify application that also handles Unicode"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
+    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
+]
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "pytokens"
@@ -3037,6 +3411,18 @@ doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+optional = false
+python-versions = "*"
+groups = ["integration"]
+files = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.3.0"
 description = "A lil' TOML parser"
@@ -3332,4 +3718,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "05ca298e193a61124546fbd9f0ca402934f7d762cd9885d71b3e4b666133b657"
+content-hash = "5b79308e349db6ee0b141247c5740746acaf246fed53251968433d5518a8e5dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ allure-pytest-default-results = "^0.1.3"
 # Azure integration tests
 azure-identity = "^1.23.0"
 azure-storage-blob = "^12.25.1"
-oauth_tools = { git = "https://github.com/canonical/iam-bundle", rev = "921d113325eed156e5b54f97c42e6c50810180c0" }
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,12 @@ dynamic = []
 description = "Shared and reusable code for OpenSearch charms"
 readme = "README.md"
 license = "Apache-2.0"
-authors = [
-]
+authors = []
 classifiers = [
- "Development Status :: 3 - Alpha",
- "Intended Audience :: Developers",
- "Intended Audience :: System Administrators",
- "Operating System :: POSIX :: Linux",
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "Operating System :: POSIX :: Linux",
 ]
 requires-python = ">=3.10,<4.0"
 version = "0.0.1.post6.dev0+744f8cb.dirty"
@@ -29,9 +28,7 @@ repository = "https://github.com/canonical/opensearch-single-kernel-library"
 [tool.poetry]
 requires-poetry = ">=2.0.0"
 package-mode = true
-packages = [
-    {include = "opensearch_single_kernel"},
-]
+packages = [{ include = "opensearch_single_kernel" }]
 include = ["opensearch_single_kernel/templates/"]
 exclude = ["opensearch_single_kernel/charmcraft.yaml"]
 
@@ -65,6 +62,7 @@ jsonschema = "^4.24.0"
 # grafana_agent/v0/cos_agent.py
 cosl = "^1.0.0"
 bcrypt = "^4.3.0"
+email-validator = ">=2"
 
 
 [tool.poetry.group.format]
@@ -120,6 +118,7 @@ allure-pytest-default-results = "^0.1.3"
 # Azure integration tests
 azure-identity = "^1.23.0"
 azure-storage-blob = "^12.25.1"
+oauth_tools = { git = "https://github.com/canonical/iam-bundle", rev = "921d113325eed156e5b54f97c42e6c50810180c0" }
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"
@@ -131,7 +130,6 @@ vcs = "git"
 dirty = true
 strict = true
 fix-shallow-repository = true
-
 
 
 [build-system]

--- a/tests/charms/opensearch_test_charm/metadata.yaml
+++ b/tests/charms/opensearch_test_charm/metadata.yaml
@@ -41,7 +41,7 @@ requires:
     limit: 1
   peer-cluster:
     interface: peer_cluster
-    limit: 2  # (main+failover)_cluster_orchestrator(s)
+    limit: 2 # (main+failover)_cluster_orchestrator(s)
     optional: true
   s3-credentials:
     interface: s3
@@ -57,9 +57,10 @@ requires:
     interface: jwt
     limit: 1
     optional: true
-
+  smtp:
+    interface: smtp
 
 storage:
   opensearch-data:
     type: filesystem
-    location: /var/snap/opensearch/common  # /mnt/opensearch/data
+    location: /var/snap/opensearch/common # /mnt/opensearch/data

--- a/tests/charms/opensearch_test_charm/poetry.lock
+++ b/tests/charms/opensearch_test_charm/poetry.lock
@@ -472,6 +472,43 @@ files = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["charm-libs"]
+files = [
+    {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
+    {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
+]
+
+[package.extras]
+dev = ["black (>=25.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.17.0)", "mypy (>=1.17)", "pylint (>=3)", "pytest (>=8.4)", "pytest-cov (>=6.2.0)", "quart-trio (>=0.12.0)", "sphinx (>=8.2.0)", "sphinx-rtd-theme (>=3.0.0)", "twine (>=6.1.0)", "wheel (>=0.45.0)"]
+dnssec = ["cryptography (>=45)"]
+doh = ["h2 (>=4.2.0)", "httpcore (>=1.0.0)", "httpx (>=0.28.0)"]
+doq = ["aioquic (>=1.2.0)"]
+idna = ["idna (>=3.10)"]
+trio = ["trio (>=0.30)"]
+wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+description = "A robust email address syntax and deliverability validation library."
+optional = false
+python-versions = ">=3.8"
+groups = ["charm-libs"]
+files = [
+    {file = "email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"},
+    {file = "email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426"},
+]
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+idna = ">=2.0.0"
+
+[[package]]
 name = "filelock"
 version = "3.20.0"
 description = "A platform independent file lock."
@@ -504,7 +541,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "charm-libs"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -648,7 +685,7 @@ develop = false
 boto3 = "^1.38.36"
 charmlibs-pathops = "^1.0.1"
 cryptography = "^45.0.4"
-data-platform-helpers = "^0.1.7"
+data-platform-helpers = "^0.1.4"
 jsonschema = "^4.24.0"
 ops = "^3.3.0"
 overrides = "^7.7.0"
@@ -1424,4 +1461,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "5c58a1c2dba83b55133a1687e23949be56e96168384744cbed1ca351f69e9fc0"
+content-hash = "61e4c4756e1ba888c2faee55262d8f843a4a353d11e603731ae9121bd4c1bded"

--- a/tests/charms/opensearch_test_charm/pyproject.toml
+++ b/tests/charms/opensearch_test_charm/pyproject.toml
@@ -23,7 +23,7 @@ cryptography = "^45.0.4"
 jsonschema = "^4.24.0"
 data-platform-helpers = "^0.1.7"
 poetry-core = "<2.0.0"
-opensearch-single-kernel-library = {path = "opensearch_single_kernel"}
+opensearch-single-kernel-library = { path = "opensearch_single_kernel" }
 
 
 [tool.poetry.group.charm-libs.dependencies]
@@ -38,6 +38,7 @@ jsonschema = "^4.24.0"
 # grafana_agent/v0/cos_agent.py
 cosl = "^1.0.0"
 bcrypt = "^4.3.0"
+email-validator = ">=2"
 
 
 [build-system]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -890,3 +890,54 @@ async def app_name(ops_test: OpsTest) -> str | None:
             return name
 
     return list(opensearch_apps.keys())[0] if opensearch_apps else None
+
+
+async def get_unit_relation_data(
+    ops_test: OpsTest,
+    unit_name: str,
+    target_unit_name: str,
+    relation_name: str,
+    key: str,
+    relation_id: str = None,
+) -> Optional[str]:
+    """Get relation data for an application.
+
+    Args:
+        ops_test: The ops test framework instance
+        unit_name: The name of the unit
+        relation_name: name of the relation to get connection data from
+        key: key of data to be retrieved
+        relation_id: id of the relation to get connection data from
+
+    Returns:
+        the data that was requested or None
+            if no data in the relation
+
+    Raises:
+        ValueError if it's not possible to get application unit data
+            or if there is no data for the particular relation endpoint
+            and/or alias.
+    """
+    raw_data = (await ops_test.juju("show-unit", unit_name))[1]
+    if not raw_data:
+        raise ValueError(f"no unit info could be grabbed for {unit_name}")
+    data = yaml.safe_load(raw_data)
+    # Filter the data based on the relation name.
+    relation_data = [v for v in data[unit_name]["relation-info"] if v["endpoint"] == relation_name]
+    if relation_id:
+        # Filter the data based on the relation id.
+        relation_data = [v for v in relation_data if v["relation-id"] == relation_id]
+    if not relation_data:
+        raise ValueError(
+            f"no relation data could be grabbed on relation with endpoint {relation_name}"
+        )
+    # Consider the case we are dealing with subordinate charms, e.g. grafana-agent
+    # The field "relation-units" is structured slightly different.
+    for idx in range(len(relation_data)):
+        if target_unit_name in relation_data[idx]["related-units"]:
+            break
+    else:
+        return {}
+    return (
+        relation_data[idx]["related-units"].get(target_unit_name, {}).get("data", {}).get(key, {})
+    )

--- a/tests/integration/plugins/__init__.py
+++ b/tests/integration/plugins/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/integration/plugins/helpers.py
+++ b/tests/integration/plugins/helpers.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper functions related to testing the different plugins."""
+import json
+import logging
+import random
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from pytest_operator.plugin import OpsTest
+from tenacity import (
+    RetryError,
+    Retrying,
+    TryAgain,
+    retry,
+    stop_after_attempt,
+    stop_after_delay,
+    wait_fixed,
+    wait_random,
+)
+
+from ..ha.helpers_data import bulk_insert, create_index
+from ..helpers import http_request
+
+logger = logging.getLogger(__name__)
+
+
+def generate_bulk_training_data(
+    index_name: str,
+    vector_name: str,
+    docs_count: int = 100,
+    dimensions: int = 4,
+    has_result: bool = False,
+) -> Tuple[str, List[str]]:
+    random.seed("seed")
+    print("The seed for randomness is: 'seed'")
+
+    data = random.randbytes(docs_count * dimensions)
+    if has_result:
+        responses = random.randbytes(docs_count)
+    result = ""
+    result_list = []
+    for i in range(docs_count):
+        result += json.dumps({"index": {"_index": index_name, "_id": i}}) + "\n"
+        result_list.append([float(data[j]) for j in range(i * dimensions, (i + 1) * dimensions)])
+        inter = {vector_name: result_list[i]}
+        if has_result:
+            inter["price"] = float(responses[i])
+        result += json.dumps(inter) + "\n"
+    return result, result_list
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def run_knn_training(
+    ops_test: OpsTest,
+    app: str,
+    unit_ip: str,
+    model_name: str,
+    payload: Dict[str, Any],
+) -> Optional[List[Dict[str, Any]]]:
+    """Sets models."""
+    endpoint = f"https://{unit_ip}:9200/_plugins/_knn/models/{model_name}/_train"
+    return await http_request(ops_test, "POST", endpoint, payload=payload, app=app)
+
+
+async def is_knn_training_complete(
+    ops_test: OpsTest,
+    app: str,
+    unit_ip: str,
+    model_name: str,
+) -> bool:
+    """Waits training models."""
+    endpoint = f"https://{unit_ip}:9200/_plugins/_knn/models/{model_name}"
+    try:
+        for attempt in Retrying(stop=stop_after_attempt(15), wait=wait_fixed(wait=5)):
+            with attempt:
+                resp = await http_request(ops_test, "GET", endpoint, app=app)
+                if "created" not in resp.get("state", ""):
+                    raise Exception
+                return True
+    except RetryError:
+        return False
+
+
+async def create_index_and_bulk_insert(
+    ops_test: OpsTest,
+    app: str,
+    endpoint: str,
+    index_name: str,
+    shards: int,
+    vector_name: str,
+    model_name: str = None,
+) -> List[float]:
+    if model_name:
+        extra_mappings = {
+            "properties": {
+                vector_name: {
+                    "type": "knn_vector",
+                    "model_id": model_name,
+                }
+            }
+        }
+        extra_index_settings = {"knn": "true"}
+    else:
+        extra_mappings = {
+            "properties": {
+                vector_name: {
+                    "type": "knn_vector",
+                    "dimension": 4,
+                }
+            }
+        }
+        extra_index_settings = {}
+
+    await create_index(
+        ops_test,
+        app,
+        endpoint,
+        index_name,
+        r_shards=shards,
+        extra_index_settings=extra_index_settings,
+        extra_mappings=extra_mappings,
+    )
+    payload, payload_list = generate_bulk_training_data(
+        index_name, vector_name, docs_count=1000, dimensions=4, has_result=True
+    )
+    # Insert data in bulk
+    await bulk_insert(ops_test, app, endpoint, payload)
+    return payload_list
+
+
+def bulk_encode(docs: List[Dict[str, Any]], index_name: str) -> str:
+    """Helper method to encode docs for bulk insert"""
+    lines = []
+    for doc in docs:
+        lines.append(json.dumps({"index": {"_index": index_name}}))
+        lines.append(json.dumps(doc))
+
+    return "\n".join(lines) + "\n"
+
+
+async def poll_until(
+    ops_test: OpsTest,
+    endpoint: str,
+    condition: Callable,
+    timeout: int = 60,
+    interval: int = 5,
+) -> bool:
+    """Poll endpoint until condition is true or timeout"""
+    logger.info(f"Polling {endpoint}...")
+    try:
+        for attempt in Retrying(
+            stop=stop_after_delay(timeout), wait=wait_fixed(wait=interval), reraise=True
+        ):
+            with attempt:
+                response = await http_request(ops_test, "GET", endpoint)
+                if condition(response):
+                    logger.info(f"Done. Condition met: {response}")
+                    return True
+                logger.info(f"Condition not met: {response}")
+                raise TryAgain
+    except RetryError:
+        logger.info("Polling timed out")
+        return False

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -1,0 +1,1704 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.conftest import APP_NAME, CONFIG_OPTS, MODEL_CONFIG
+from tests.integration.ha.helpers_data import (
+    bulk_insert,
+    create_index,
+    delete_index,
+    index_doc,
+    search,
+)
+from tests.integration.ha.test_horizontal_scaling import IDLE_PERIOD
+from tests.integration.helpers import (
+    app_name,
+    get_application_unit_ids_ips,
+    get_leader_unit_id,
+    get_leader_unit_ip,
+    get_secret_by_label,
+    get_unit_relation_data,
+    http_request,
+    run_action,
+    set_watermark,
+    wait_until,
+)
+
+from ..plugins.helpers import (
+    bulk_encode,
+    create_index_and_bulk_insert,
+    generate_bulk_training_data,
+    is_knn_training_complete,
+    poll_until,
+    run_knn_training,
+)
+from ..profiles.test_profiles import get_constraints
+from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
+
+logger = logging.getLogger(__name__)
+
+
+COS_APP_NAME = "grafana-agent"
+COS_CHANNEL = "1/stable"
+COS_RELATION_NAME = "cos-agent"
+DASHBOARDS_APP_NAME = "opensearch-dashboards"
+MAIN_ORCHESTRATOR_NAME = "main"
+FAILOVER_ORCHESTRATOR_NAME = "failover"
+SMTP_INTEGRATOR_APP_NAME = "smtp-integrator"
+SMTP_INTEGRATOR_CHANNEL = "latest/edge"
+
+
+ALL_GROUPS = {
+    deploy_type: pytest.param(
+        deploy_type,
+        id=deploy_type,
+        marks=[
+            pytest.mark.group(id=deploy_type),
+        ],
+    )
+    for deploy_type in ["large_deployment", "small_deployment"]
+}
+
+ALL_DEPLOYMENTS = list(ALL_GROUPS.values())
+SMALL_DEPLOYMENTS = [ALL_GROUPS["small_deployment"]]
+LARGE_DEPLOYMENTS = [ALL_GROUPS["large_deployment"]]
+
+TEST_INDEX = "test-index"
+TEST_DOCS = [
+    {"passage_text": "Hello world", "id": "s1", "test_field": "us-west-2"},
+    {"passage_text": "Hi planet", "id": "s2", "test_field": "us-east-1"},
+]
+INGEST_PIPELINE_ID = "test-ingest-pipeline"
+TEXT_EMBEDDING_OUTPUT_DIM = 384
+TEXT_EMBEDDING_MODEL = {
+    "name": "huggingface/sentence-transformers/all-MiniLM-L6-v2",
+    "version": "1.0.1",
+    "model_format": "TORCH_SCRIPT",
+}
+
+
+async def _wait_for_units(
+    ops_test: OpsTest,
+    deployment_type: str,
+    wait_for_cos: bool = False,
+) -> None:
+    """Wait for all units to be active.
+
+    This wait will behavior accordingly to small/large.
+    """
+    if deployment_type == "small_deployment":
+        await wait_until(
+            ops_test,
+            apps=[APP_NAME],
+            apps_statuses=["active"],
+            units_statuses=["active"],
+            timeout=1800,
+            wait_for_exact_units={APP_NAME: 3},
+            idle_period=IDLE_PERIOD,
+        )
+        if wait_for_cos:
+            await wait_until(
+                ops_test,
+                apps=[COS_APP_NAME],
+                units_statuses=["blocked"],
+                timeout=1800,
+                idle_period=IDLE_PERIOD,
+            )
+        return
+    await wait_until(
+        ops_test,
+        apps=[
+            TLS_CERTIFICATES_APP_NAME,
+            MAIN_ORCHESTRATOR_NAME,
+            FAILOVER_ORCHESTRATOR_NAME,
+            APP_NAME,
+        ],
+        wait_for_exact_units={
+            TLS_CERTIFICATES_APP_NAME: 1,
+            MAIN_ORCHESTRATOR_NAME: 1,
+            FAILOVER_ORCHESTRATOR_NAME: 2,
+            APP_NAME: 1,
+        },
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        timeout=1800,
+        idle_period=IDLE_PERIOD,
+    )
+    if wait_for_cos:
+        await wait_until(
+            ops_test,
+            apps=[COS_APP_NAME],
+            units_statuses=["blocked"],
+            timeout=1800,
+            idle_period=IDLE_PERIOD,
+        )
+
+
+def _get_relation_id(model, endpoint1: str, endpoint2: str) -> int:
+    """Return relation id for endpoints like 'app:relation'."""
+    app1, rel1 = endpoint1.split(":")
+    app2, rel2 = endpoint2.split(":")
+    for rel in model.relations:
+        eps = {(e.application_name, e.name) for e in rel.endpoints}
+        if (app1, rel1) in eps and (app2, rel2) in eps:
+            return rel.id
+    raise RuntimeError(f"Relation not found between {endpoint1} and {endpoint2}")
+
+
+async def _notifications_list_configs(ops_test: OpsTest, base_url: str) -> dict[str, Any]:
+    """Fetch all notification configs from the OpenSearch Notifications plugin API.
+
+    Args:
+        ops_test: OpsTest test harness.
+        base_url: OpenSearch base URL (e.g. https://ip:9200).
+
+    Returns:
+        Response body from GET /_plugins/_notifications/configs.
+    """
+    return await http_request(ops_test, "GET", f"{base_url}/_plugins/_notifications/configs")
+
+
+def _cfg_name(item: dict) -> str | None:
+    """Return the config name from a notifications config item.
+
+    Args:
+        item: A single config item.
+
+    Returns:
+        The value of config.name, or None if missing.
+    """
+    return (item.get("config") or {}).get("name")
+
+
+def _iter_configs(configs_resp: Any):
+    """Yield config items from a notifications list-configs response.
+
+    Args:
+        configs_resp: Response body from GET /_plugins/_notifications/configs.
+
+    Yields:
+        Individual config item dicts.
+    """
+    if not isinstance(configs_resp, dict):
+        return
+    for key in ("config_list", "configs", "items"):
+        items = configs_resp.get(key)
+        if isinstance(items, list):
+            yield from items
+            return
+
+
+def _find_config_by_name(configs_resp: Any, name: str) -> dict | None:
+    """Find a notifications config item by its config name.
+
+    Args:
+        configs_resp: Response body from GET /_plugins/_notifications/configs.
+        name: The config name to match (e.g. config.config.name).
+
+    Returns:
+        The matching config item dict, or None if not found.
+    """
+    for item in _iter_configs(configs_resp):
+        if _cfg_name(item) == name:
+            return item
+    return None
+
+
+async def _wait_until_config_present(
+    ops_test: OpsTest,
+    base_url: str,
+    config_name: str,
+    timeout: int = 180,
+    poll: int = 5,
+) -> dict:
+    """Poll until a notifications config with the given name appears.
+
+    Args:
+        ops_test: Pytest plugin for Juju ops_test.
+        base_url: OpenSearch base URL (e.g. https://<ip>:9200).
+        config_name: Name of the config to wait for.
+        timeout: Maximum seconds to wait.
+        poll: Seconds between list-configs requests.
+
+    Returns:
+        The config item dict once found.
+
+    Raises:
+        asyncio.TimeoutError: If the config does not appear within timeout.
+    """
+    async with asyncio.timeout(timeout):
+        while True:
+            resp = await _notifications_list_configs(ops_test, base_url)
+            if cfg := _find_config_by_name(resp, config_name):
+                return cfg
+            await asyncio.sleep(poll)
+
+
+async def _wait_until_config_absent(
+    ops_test: OpsTest,
+    base_url: str,
+    config_name: str,
+    timeout: int = 180,
+    poll: int = 5,
+) -> None:
+    """Poll until a notifications config with the given name is no longer listed.
+
+    Args:
+        ops_test: Pytest plugin for Juju ops_test.
+        base_url: OpenSearch base URL (e.g. https://<ip>:9200).
+        config_name: Name of the config to wait for removal.
+        timeout: Maximum seconds to wait.
+        poll: Seconds between list-configs requests.
+
+    Raises:
+        asyncio.TimeoutError: If the config is still present after timeout.
+    """
+    async with asyncio.timeout(timeout):
+        while True:
+            resp = await _notifications_list_configs(ops_test, base_url)
+            if _find_config_by_name(resp, config_name) is None:
+                return
+            await asyncio.sleep(poll)
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy_small_deployment(
+    ops_test: OpsTest, charm, series, deploy_type: str
+) -> None:
+    """Build and deploy an OpenSearch cluster."""
+    if await app_name(ops_test):
+        return
+
+    model_conf = MODEL_CONFIG.copy()
+    # Make it more regular as COS relation-broken really happens on the
+    # next hook call in each opensearch unit.
+    # If this value is changed, then update the sleep accordingly at:
+    #  test_prometheus_exporter_disabled_by_cos_relation_gone
+    model_conf["update-status-hook-interval"] = "1m"
+    await ops_test.model.set_config(model_conf)
+    constraints = await get_constraints(ops_test)
+
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            num_units=3,
+            series=series,
+            constraints=constraints,
+            config={"profile": "production"},
+        ),
+        ops_test.model.deploy(
+            TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
+        ),
+    )
+
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+
+    await _wait_for_units(ops_test, deploy_type)
+    assert len(ops_test.model.applications[APP_NAME].units) == 3
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_prometheus_exporter_enabled_by_default(ops_test, deploy_type: str):
+    """Test that Prometheus Exporter is running before the relation is there.
+
+    Test only on small deployments scenario, as this is a more functional check to the plugin.
+    """
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=APP_NAME)
+    endpoint = f"https://{leader_unit_ip}:9200/_prometheus/metrics"
+    response = await http_request(ops_test, "get", endpoint, app=APP_NAME, json_resp=False)
+
+    response_str = response.content.decode("utf-8")
+    assert response_str.count("opensearch_") > 500
+    assert len(response_str.split("\n")) > 500
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9402")
+async def test_small_deployments_prometheus_exporter_cos_relation(
+    ops_test, series, deploy_type: str
+):
+    await ops_test.model.deploy(COS_APP_NAME, channel=COS_CHANNEL, series=series)
+    await ops_test.model.integrate(APP_NAME, COS_APP_NAME)
+    await _wait_for_units(ops_test, deploy_type, wait_for_cos=True)
+
+    # Check that the correct settings were successfully communicated to grafana-agent
+    cos_leader_id = await get_leader_unit_id(ops_test, COS_APP_NAME)
+    cos_leader_name = f"{COS_APP_NAME}/{cos_leader_id}"
+    leader_id = await get_leader_unit_id(ops_test, APP_NAME)
+    leader_name = f"{APP_NAME}/{leader_id}"
+    relation_data = await get_unit_relation_data(
+        ops_test, cos_leader_name, leader_name, COS_RELATION_NAME, "config"
+    )
+    if not isinstance(relation_data, dict):
+        relation_data = json.loads(relation_data)
+    relation_data = relation_data["metrics_scrape_jobs"][0]
+    secret = await get_secret_by_label(ops_test, "opensearch:app:monitor-password")
+
+    assert relation_data["basic_auth"]["username"] == "monitor"
+    assert relation_data["basic_auth"]["password"] == secret["monitor-password"]
+
+    admin_secret = await get_secret_by_label(ops_test, "opensearch:app:app-admin")
+    assert relation_data["tls_config"]["ca"] == admin_secret["ca-cert"]
+    assert relation_data["scheme"] == "https"
+
+
+@pytest.mark.parametrize("deploy_type", LARGE_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_large_deployment_build_and_deploy(
+    ops_test: OpsTest, charm, series, deploy_type: str
+) -> None:
+    """Build and deploy a large deployment for OpenSearch."""
+    await ops_test.model.set_config(MODEL_CONFIG)
+    # Deploy TLS Certificates operator.
+    tls_config = {"ca-common-name": "CN_CA"}
+
+    main_orchestrator_conf = {
+        "cluster_name": "plugins-test",
+        "init_hold": False,
+        "roles": "cluster_manager,data",
+    }
+    failover_orchestrator_conf = {
+        "cluster_name": "plugins-test",
+        "init_hold": True,
+        "roles": "cluster_manager,data",
+    }
+    data_hot_conf = {
+        "cluster_name": "plugins-test",
+        "init_hold": True,
+        "roles": "data.hot,ml",
+    }
+
+    await asyncio.gather(
+        ops_test.model.deploy(
+            TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=tls_config
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=MAIN_ORCHESTRATOR_NAME,
+            num_units=1,
+            series=series,
+            config=main_orchestrator_conf | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=FAILOVER_ORCHESTRATOR_NAME,
+            num_units=2,
+            series=series,
+            config=failover_orchestrator_conf | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=APP_NAME,
+            num_units=1,
+            series=series,
+            config=data_hot_conf | CONFIG_OPTS,
+        ),
+    )
+
+    # Large deployment setup
+    await ops_test.model.integrate("main:peer-cluster-orchestrator", "failover:peer-cluster")
+    await ops_test.model.integrate("main:peer-cluster-orchestrator", f"{APP_NAME}:peer-cluster")
+    await ops_test.model.integrate(
+        "failover:peer-cluster-orchestrator", f"{APP_NAME}:peer-cluster"
+    )
+
+    # TLS setup
+    await ops_test.model.integrate(MAIN_ORCHESTRATOR_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.integrate(FAILOVER_ORCHESTRATOR_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+
+    await _wait_for_units(ops_test, deploy_type)
+    await set_watermark(ops_test, APP_NAME)
+
+
+@pytest.mark.parametrize("deploy_type", LARGE_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_large_deployment_prometheus_exporter_cos_relation(
+    ops_test, series, deploy_type: str
+):
+    # Check that the correct settings were successfully communicated to grafana-agent
+    (await ops_test.model.deploy(COS_APP_NAME, channel=COS_CHANNEL, series=series),)
+    await ops_test.model.integrate(FAILOVER_ORCHESTRATOR_NAME, COS_APP_NAME)
+    await ops_test.model.integrate(MAIN_ORCHESTRATOR_NAME, COS_APP_NAME)
+    await ops_test.model.integrate(APP_NAME, COS_APP_NAME)
+
+    await _wait_for_units(ops_test, deploy_type, wait_for_cos=True)
+
+    leader_id = await get_leader_unit_id(ops_test, APP_NAME)
+    leader_name = f"{APP_NAME}/{leader_id}"
+
+    cos_leader_id = await get_leader_unit_id(ops_test, COS_APP_NAME)
+    relation_data = await get_unit_relation_data(
+        ops_test,
+        f"{COS_APP_NAME}/{cos_leader_id}",
+        leader_name,
+        COS_RELATION_NAME,
+        "config",
+    )
+    if not isinstance(relation_data, dict):
+        relation_data = json.loads(relation_data)
+    relation_data = relation_data["metrics_scrape_jobs"][0]
+    secret = await get_secret_by_label(ops_test, "opensearch:app:monitor-password")
+
+    assert relation_data["basic_auth"]["username"] == "monitor"
+    assert relation_data["basic_auth"]["password"] == secret["monitor-password"]
+
+    admin_secret = await get_secret_by_label(ops_test, "opensearch:app:app-admin")
+    assert relation_data["tls_config"]["ca"] == admin_secret["ca-cert"]
+    assert relation_data["scheme"] == "https"
+
+
+@pytest.mark.parametrize("deploy_type", ALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9402")
+async def test_monitoring_user_fetch_prometheus_data(ops_test, deploy_type: str):
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=APP_NAME)
+    endpoint = f"https://{leader_unit_ip}:9200/_prometheus/metrics"
+
+    secret = await get_secret_by_label(ops_test, "opensearch:app:monitor-password")
+    response = await http_request(
+        ops_test,
+        "get",
+        endpoint,
+        app=APP_NAME,
+        json_resp=False,
+        user="monitor",
+        user_password=secret["monitor-password"],
+    )
+    response_str = response.content.decode("utf-8")
+
+    assert response_str.count("opensearch_") > 500
+    assert len(response_str.split("\n")) > 500
+
+
+@pytest.mark.parametrize("deploy_type", ALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9402")
+async def test_prometheus_monitor_user_password_change(ops_test, deploy_type: str):
+    # Password change applied as expected
+    app = APP_NAME if deploy_type == "small_deployment" else MAIN_ORCHESTRATOR_NAME
+
+    leader_id = await get_leader_unit_id(ops_test, app)
+    result1 = await run_action(
+        ops_test, leader_id, "set-password", {"username": "monitor"}, app=app
+    )
+    await _wait_for_units(ops_test, deploy_type, wait_for_cos=True)
+
+    new_password = result1.response.get("monitor-password")
+    # Now, we compare the change in the action above with the opensearch's nodes.
+    # In large deployments, that will mean checking if the change on main orchestrator
+    # was sent down to the opensearch (data node) cluster.
+    result2 = await run_action(
+        ops_test, leader_id, "get-password", {"username": "monitor"}, app=app
+    )
+    assert result2.response.get("password") == new_password
+
+    # Relation data is updated
+    # In both large and small deployments, we want to check if the relation data is updated
+    # on the data node: "opensearch"
+    leader_id = await get_leader_unit_id(ops_test, APP_NAME)
+    leader_name = f"{APP_NAME}/{leader_id}"
+
+    # We're not sure which grafana-agent is sitting with APP_NAME in large deployments
+    cos_leader_id = await get_leader_unit_id(ops_test, COS_APP_NAME)
+    relation_data = await get_unit_relation_data(
+        ops_test,
+        f"{COS_APP_NAME}/{cos_leader_id}",
+        leader_name,
+        COS_RELATION_NAME,
+        "config",
+    )
+    if not isinstance(relation_data, dict):
+        relation_data = json.loads(relation_data)
+    relation_data = relation_data["metrics_scrape_jobs"][0]["basic_auth"]
+
+    assert relation_data["username"] == "monitor"
+    assert relation_data["password"] == new_password
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_knn_search_with_hnsw_faiss(ops_test: OpsTest, deploy_type: str) -> None:
+    """Uploads data and runs a query search against the FAISS KNNEngine."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    # create index with r_shards = nodes - 1
+    index_name = "test_search_with_hnsw_faiss"
+    vector_name = "test_search_with_hnsw_faiss_vector"
+    await create_index(
+        ops_test,
+        app,
+        leader_unit_ip,
+        index_name,
+        r_shards=len(units) - 1,
+        extra_index_settings={"knn": "true", "knn.algo_param.ef_search": 100},
+        extra_mappings={
+            "properties": {
+                vector_name: {
+                    "type": "knn_vector",
+                    "dimension": 4,
+                    "method": {
+                        "name": "hnsw",
+                        "space_type": "innerproduct",
+                        "engine": "faiss",
+                        "parameters": {"ef_construction": 256, "m": 48},
+                    },
+                }
+            }
+        },
+    )
+    payload, payload_list = generate_bulk_training_data(
+        index_name, vector_name, docs_count=100, dimensions=4, has_result=True
+    )
+    # Insert data in bulk
+    await bulk_insert(ops_test, app, leader_unit_ip, payload)
+    query = {
+        "size": 2,
+        "query": {"knn": {vector_name: {"vector": payload_list[0], "k": 2}}},
+    }
+    docs = await search(ops_test, app, leader_unit_ip, index_name, query, retries=30)
+    assert len(docs) == 2
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_knn_search_with_hnsw_nmslib(ops_test: OpsTest, deploy_type: str) -> None:
+    """Uploads data and runs a query search against the NMSLIB KNNEngine."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    # create index with r_shards = nodes - 1
+    index_name = "test_search_with_hnsw_nmslib"
+    vector_name = "test_search_with_hnsw_nmslib_vector"
+    await create_index(
+        ops_test,
+        app,
+        leader_unit_ip,
+        index_name,
+        r_shards=len(units) - 1,
+        extra_index_settings={"knn": "true", "knn.algo_param.ef_search": 100},
+        extra_mappings={
+            "properties": {
+                vector_name: {
+                    "type": "knn_vector",
+                    "dimension": 4,
+                    "method": {
+                        "name": "hnsw",
+                        "space_type": "l2",
+                        "engine": "nmslib",
+                        "parameters": {"ef_construction": 256, "m": 48},
+                    },
+                }
+            }
+        },
+    )
+    payload, payload_list = generate_bulk_training_data(
+        index_name, vector_name, docs_count=100, dimensions=4, has_result=True
+    )
+    # Insert data in bulk
+    await bulk_insert(ops_test, app, leader_unit_ip, payload)
+    query = {
+        "size": 2,
+        "query": {"knn": {vector_name: {"vector": payload_list[0], "k": 2}}},
+    }
+    docs = await search(ops_test, app, leader_unit_ip, index_name, query, retries=30)
+    assert len(docs) == 2
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_knn_training_search(ops_test: OpsTest, deploy_type: str) -> None:
+    """Tests the entire cycle of KNN plugin.
+
+    1) Enters data and trains a model in "test_end_to_end_with_ivf_faiss_training"
+    2) Trains model: "test_end_to_end_with_ivf_faiss_model"
+    3) Once training is complete, creates a target index and connects with the model
+    4) Disables KNN plugin: the search must fail
+    5) Re-enables the plugin: search must succeed and return two vectors.
+    """
+    app = (await app_name(ops_test)) or APP_NAME
+
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+    # Get since when each unit has been active
+
+    # create index with r_shards = nodes - 1
+    index_name = "test_end_to_end_with_ivf_faiss_training"
+    vector_name = "test_end_to_end_with_ivf_faiss_vector"
+    model_name = "test_end_to_end_with_ivf_faiss_model"
+    await create_index_and_bulk_insert(
+        ops_test, app, leader_unit_ip, index_name, len(units) - 1, vector_name
+    )
+    await run_knn_training(
+        ops_test,
+        app,
+        leader_unit_ip,
+        model_name,
+        {
+            "training_index": index_name,
+            "training_field": vector_name,
+            "dimension": 4,
+            "method": {
+                "name": "ivf",
+                "engine": "faiss",
+                "space_type": "l2",
+                "parameters": {"nlist": 4, "nprobes": 2},
+            },
+        },
+    )
+    # wait for training to finish -> fails with an exception otherwise
+    assert await is_knn_training_complete(
+        ops_test, app, leader_unit_ip, model_name
+    ), "KNN training did not complete."
+
+    # Creates the target index, to use the model
+    payload_list = await create_index_and_bulk_insert(
+        ops_test,
+        app,
+        leader_unit_ip,
+        "test_end_to_end_with_ivf_faiss_target",
+        len(units) - 1,
+        vector_name="target-field",
+        model_name=model_name,
+    )
+
+    query = {
+        "size": 2,
+        "query": {"knn": {"target-field": {"vector": payload_list[0], "k": 2}}},
+    }
+
+    docs = await search(
+        ops_test,
+        app,
+        leader_unit_ip,
+        "test_end_to_end_with_ivf_faiss_target",
+        query,
+        retries=3,
+    )
+    assert len(docs) == 2, f"Unexpected search results count: {len(docs)}."
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9258")
+async def test_reports_scheduler(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the reports scheduler plugin is enabled and functional."""
+    # Deploy OpenSearch Dashboards
+    await ops_test.model.deploy(
+        DASHBOARDS_APP_NAME,
+        channel="2/edge",
+    )
+    await ops_test.model.integrate(DASHBOARDS_APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.integrate(DASHBOARDS_APP_NAME, APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[DASHBOARDS_APP_NAME, APP_NAME],
+        status="active",
+    )
+    dashboards_leader_unit_ip = await get_leader_unit_ip(ops_test, app=DASHBOARDS_APP_NAME)
+    dashboards_base_url = f"https://{dashboards_leader_unit_ip}:5601"
+
+    # download sample data
+    sample_data = "ecommerce"
+    logger.info(f"Downloading sample {sample_data} data...")
+    response = await http_request(
+        ops_test,
+        "POST",
+        f"{dashboards_base_url}/api/sample_data/{sample_data}",
+        extra_headers={"osd-xsrf": "true"},
+    )
+    logger.info(f"Download response: {response}")
+    assert response["opensearchIndicesCreated"], f"Sample data '{sample_data}' not downloaded"
+
+    logger.info("Finding a dashboard..")
+    response = await http_request(
+        ops_test,
+        "GET",
+        f"{dashboards_base_url}/api/saved_objects/_find?type=dashboard&search_fields=title&search={sample_data}",
+    )
+    logger.info(f"Search fields response: {response}")
+    dashboard_id = response["saved_objects"][0]["id"]
+
+    start = int(datetime.now(timezone.utc).timestamp() * 1000)
+    payload = {
+        "reportDefinition": {
+            "name": f"{sample_data}-report-definition",
+            "isEnabled": True,
+            "source": {
+                "description": f"{sample_data} report",
+                "type": "Dashboard",
+                "origin": dashboards_base_url,
+                "id": dashboard_id,
+            },
+            "format": {"duration": "PT12H", "fileFormat": "Pdf"},
+            "trigger": {
+                "triggerType": "IntervalSchedule",
+                "schedule": {"interval": {"start_time": start, "period": 1, "unit": "Minutes"}},
+            },
+            "delivery": {
+                "title": "",
+                "textDescription": "",
+                "htmlDescription": "",
+                "configIds": [],
+            },
+        }
+    }
+
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    # set job interval to 1m (min value)
+    settings = {
+        "persistent": {
+            "plugins.index_state_management.job_interval": 1,
+            "plugins.index_state_management.jitter": 0,
+        }
+    }
+
+    await http_request(
+        ops_test,
+        "PUT",
+        f"{base_url}/_cluster/settings",
+        settings,
+    )
+    endpoint = f"{base_url}/_plugins/_reports"
+
+    logger.info("Creating report definition...")
+    response = await http_request(ops_test, "POST", f"{endpoint}/definition", payload)
+
+    logger.info(f"Report definition response: {response}")
+    report_definition_id = response["reportDefinitionId"]
+
+    logger.info("Wait for schedule interval time to pass...")
+    await asyncio.sleep(60)
+
+    logger.info("Poll for report instance creation")
+    await poll_until(
+        ops_test,
+        f"{endpoint}/instances",
+        lambda instances: instances.get("totalHits") > 0,
+        timeout=60 * 3,
+    )
+
+    # fetch report instance
+    response = await http_request(ops_test, "GET", f"{endpoint}/instances")
+    logger.info(f"Instances {response}")
+    assert report_definition_id in [
+        instance["reportDefinitionDetails"]["id"] for instance in response["reportInstanceList"]
+    ], "Could not find report instance from report definition"
+
+    # delete report definition
+    await http_request(ops_test, "DELETE", f"{endpoint}/definition/{report_definition_id}")
+
+    # delete sample data
+    await http_request(ops_test, "DELETE", f"{dashboards_base_url}/api/sample_data/{sample_data}")
+
+    # remove dashboards application
+    await ops_test.model.remove_application(DASHBOARDS_APP_NAME, block_until_done=True)
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_sql_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the SQL plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    # create index
+    await create_index(ops_test, APP_NAME, leader_unit_ip, TEST_INDEX)
+
+    # insert test docs
+    await bulk_insert(ops_test, APP_NAME, leader_unit_ip, bulk_encode(TEST_DOCS, TEST_INDEX))
+    await http_request(ops_test, "POST", f"{base_url}/{TEST_INDEX}/_refresh")
+
+    # select target doc
+    target = TEST_DOCS[-1]
+    target_id = target["id"]
+    target_text = target["passage_text"]
+
+    # create query
+    query = {"query": f"SELECT id, passage_text FROM {TEST_INDEX} WHERE id = '{target_id}'"}
+    endpoint = f"https://{leader_unit_ip}:9200/_plugins/_sql"
+    response = await http_request(ops_test, "POST", endpoint, query)
+    logger.info(f"SQL query response: {response}")
+    assert response.get("size") == 1, "Unexpected SQL result"
+    assert response.get("datarows")[0][-1] == target_text, "Unexpected SQL result"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9258")
+async def test_ism_and_job_scheduler_plugins(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the ISM and job scheduler plugins are enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    # create index with alias
+    index_alias = "ism-test"
+    initial_index = f"{index_alias}-000001"
+    expected_end_index = (
+        f"{index_alias}-000002"  # after rollover the new index will have the number incremented
+    )
+    await create_index(
+        ops_test,
+        APP_NAME,
+        leader_unit_ip,
+        initial_index,
+        extra_index_settings={"plugins.index_state_management.rollover_alias": index_alias},
+    )
+
+    # set alias
+    await http_request(
+        ops_test,
+        "PUT",
+        f"{base_url}/{initial_index}/_alias/{index_alias}",
+        {"is_write_index": True},
+    )
+
+    # create policy to rollover index after min doc count (1)
+    policy_id = "rollover"
+    rollover = {
+        "policy": {
+            "description": "rollover",
+            "default_state": "hot",
+            "states": [
+                {
+                    "name": "hot",
+                    "actions": [{"rollover": {"min_doc_count": 1}}],
+                    "transitions": [],
+                }
+            ],
+        }
+    }
+    await http_request(ops_test, "PUT", f"{base_url}/_plugins/_ism/policies/{policy_id}", rollover)
+
+    # attach policy
+    await http_request(
+        ops_test,
+        "POST",
+        f"{base_url}/_plugins/_ism/add/{initial_index}",
+        {"policy_id": policy_id},
+    )
+
+    # add doc to trigger rollover
+    await index_doc(ops_test, APP_NAME, leader_unit_ip, index_alias, 1)
+
+    # wait for job interval time (1m) to pass for job scheduler to run policy checks
+    logger.info("Waiting for job interval to pass before polling for index rollover...")
+    await asyncio.sleep(60)
+
+    # poll if new index created (should trigger within 1m but can take longer)
+    assert await poll_until(
+        ops_test,
+        f"{base_url}/_alias/{index_alias}",
+        lambda aliases: expected_end_index in aliases,
+        timeout=60 * 3,
+    ), "Index did not rollover before timeout"
+
+    # delete indices
+    await delete_index(ops_test, APP_NAME, leader_unit_ip, initial_index)
+    await delete_index(ops_test, APP_NAME, leader_unit_ip, expected_end_index)
+    await http_request(ops_test, "DELETE", f"{base_url}/_plugins/_ism/policies/{policy_id}")
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_anomaly_detection(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the anomaly plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    detectors_url = f"{base_url}/_plugins/_anomaly_detection/detectors"
+
+    anomaly_index = "anomaly-index"
+    await create_index(
+        ops_test,
+        APP_NAME,
+        leader_unit_ip,
+        anomaly_index,
+        extra_mappings={
+            "properties": {"timestamp": {"type": "date"}, "value": {"type": "double"}}
+        },
+    )
+    # insert time series data with an anomaly
+    start = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    n = 500
+    anomaly = 1000.0
+    docs = []
+    for i in range(n):
+        timestamp = (start + timedelta(minutes=i)).isoformat().replace("+00:00", "Z")
+        value = anomaly if i == 200 else 10.0 + (i % 5)
+        docs.append({"timestamp": timestamp, "value": value})
+
+    await bulk_insert(ops_test, APP_NAME, leader_unit_ip, bulk_encode(docs, anomaly_index))
+    await http_request(ops_test, "POST", f"{base_url}/{anomaly_index}/_refresh")
+
+    # create detector
+    detector = {
+        "name": "anomaly-detection",
+        "time_field": "timestamp",
+        "indices": [anomaly_index],
+        "feature_attributes": [
+            {
+                "feature_name": "sum_value",
+                "feature_enabled": True,
+                "aggregation_query": {"sum_value": {"sum": {"field": "value"}}},
+            }
+        ],
+        "detection_interval": {"period": {"interval": 1, "unit": "Minutes"}},
+    }
+    response = await http_request(ops_test, "POST", detectors_url, detector)
+    logger.info(f"Detector creation response {response}")
+    detector_id = response.get("_id")
+    assert detector_id, "Detector not created"
+
+    # run detector
+    start_time = int(start.timestamp() * 1000)
+    end_time = int((start + timedelta(minutes=n)).timestamp() * 1000)
+    response = await http_request(
+        ops_test,
+        "POST",
+        f"{detectors_url}/{detector_id}/_start",
+        {
+            "start_time": start_time,
+            "end_time": end_time,
+        },
+    )
+    task_id = response.get("_id")
+    assert task_id, "Anomaly detection task not created"
+
+    # task will complete almost immediately
+    await asyncio.sleep(5)
+
+    payload = {
+        "query": {
+            "bool": {
+                "filter": [
+                    {"term": {"detector_id": detector_id}},
+                    {"range": {"anomaly_grade": {"gt": 0}}},
+                    {"term": {"task_id": task_id}},
+                ]
+            }
+        }
+    }
+
+    response = await http_request(ops_test, "POST", f"{detectors_url}/results/_search", payload)
+    logger.info(f"Anomaly results search response: {response}")
+    assert response.get("hits", {}).get("total", {}).get("value", 0) > 0, "No anomalies found"
+    assert (
+        response.get("hits").get("hits")[0].get("_source").get("feature_data")[0].get("data")
+        == anomaly
+    ), "Unexpected anomaly result"
+
+    # stop detector
+    await http_request(ops_test, "POST", f"{detectors_url}/{detector_id}/_stop")
+    await http_request(ops_test, "DELETE", f"{detectors_url}/{detector_id}")
+    await delete_index(ops_test, APP_NAME, leader_unit_ip, anomaly_index)
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_async_search_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the async search plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    endpoint = f"{base_url}/_plugins/_asynchronous_search"
+
+    # create async search
+    payload = {
+        "query": {"match_all": {}},
+        "size": 1,
+    }
+    response = await http_request(
+        ops_test,
+        "POST",
+        f"{endpoint}?index={TEST_INDEX}&wait_for_completion_timeout=0s&keep_on_completion=true",
+        payload,
+    )
+    logger.info(f"Async Search response: {response}")
+    async_job_id = response.get("id")
+    assert async_job_id, "Async search job not created"
+
+    # poll until complete
+    logger.info("Waiting for async search job to complete...")
+    assert await poll_until(
+        ops_test,
+        f"{endpoint}/{async_job_id}",
+        lambda progress: progress.get("state") == "STORE_RESIDENT",
+    ), "Async search did not complete before timeout"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_alerting_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the alerting plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    endpoint = f"{base_url}/_plugins/_alerting/monitors"
+
+    # create monitor
+    payload = {
+        "name": "alerting-test",
+        "monitor_type": "query_level_monitor",
+        "schedule": {"period": {"interval": 1, "unit": "MINUTES"}},
+        "inputs": [
+            {
+                "search": {
+                    "indices": [TEST_INDEX],
+                    "query": {"size": 0, "query": {"match_all": {}}},
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "name": "has_docs",
+                "severity": "1",
+                "condition": {"script": {"source": "ctx.results[0].hits.total.value > 0"}},
+                "actions": [],
+            }
+        ],
+    }
+
+    response = await http_request(ops_test, "POST", endpoint, payload)
+    monitor_id = response.get("_id")
+    assert monitor_id, "Alerting monitor not created"
+
+    logger.info(f"Executing alerting monitor {monitor_id}")
+    response = await http_request(
+        ops_test,
+        "POST",
+        f"{endpoint}/{monitor_id}/_execute",
+        payload={"periodStart": "now-30m", "periodEnd": "now"},
+    )
+
+    logger.info(f"Monitor execution response: {response}")
+    trigger_results = list(response.get("trigger_results", {}).values())
+    assert len(trigger_results) > 0, "No alert trigger results"
+    assert trigger_results[0]["triggered"], "Alert not triggered"
+
+    # check alerts
+    response = await http_request(
+        ops_test,
+        "GET",
+        f"{base_url}/_plugins/_alerting/monitors/alerts?monitorId={monitor_id}",
+    )
+
+    assert response.get("totalAlerts", 0) > 0, "No alerts found"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_query_insights_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the query insights plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    response = await http_request(ops_test, "GET", f"{base_url}/_insights/top_queries")
+    assert response.get("top_queries"), "No top queries returned"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_notifications_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the notifications plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    notifications_endpoint = f"{base_url}/_plugins/_notifications"
+
+    response = await http_request(ops_test, "GET", f"{notifications_endpoint}/features")
+    assert response.get("allowed_config_type_list")
+
+    # create channel
+    payload = {
+        "config": {
+            "name": "test-webhook",
+            "config_type": "webhook",
+            "is_enabled": True,
+            "webhook": {"url": "http://127.0.0.1:9200"},  # connection will be refused
+        }
+    }
+    logger.info("Creating notification channel")
+    response = await http_request(ops_test, "POST", f"{notifications_endpoint}/configs", payload)
+    channel_id = response.get("config_id")
+    assert channel_id, "Notification channel not created"
+    logger.info(f"Created: {channel_id}")
+
+    # attempt to send test notification
+    logger.info(f"Attempting test notification to channel {channel_id} (attempt should fail)")
+    response = await http_request(
+        ops_test, "GET", f"{notifications_endpoint}/feature/test/{channel_id}"
+    )
+
+    logger.info(f"Notifications test response: {response}")
+    assert (
+        "Failed to send webhook" in response["error"]["reason"]
+    ), "Did not attempt to send webhook notification"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_ml_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the ML plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    # train and predict
+    payload = {
+        "parameters": {"centroids": 2, "iterations": 1, "distance_type": "EUCLIDEAN"},
+        "input_data": {
+            "column_metas": [
+                {"name": "k1", "column_type": "DOUBLE"},
+                {"name": "k2", "column_type": "DOUBLE"},
+            ],
+            "rows": [
+                {
+                    "values": [
+                        {"column_type": "DOUBLE", "value": 1.0},
+                        {"column_type": "DOUBLE", "value": 2.0},
+                    ]
+                },
+                {
+                    "values": [
+                        {"column_type": "DOUBLE", "value": 1.0},
+                        {"column_type": "DOUBLE", "value": 4.0},
+                    ]
+                },
+                {
+                    "values": [
+                        {"column_type": "DOUBLE", "value": 1.0},
+                        {"column_type": "DOUBLE", "value": 0.0},
+                    ]
+                },
+                {
+                    "values": [
+                        {"column_type": "DOUBLE", "value": 10.0},
+                        {"column_type": "DOUBLE", "value": 2.0},
+                    ]
+                },
+                {
+                    "values": [
+                        {"column_type": "DOUBLE", "value": 10.0},
+                        {"column_type": "DOUBLE", "value": 4.0},
+                    ]
+                },
+                {
+                    "values": [
+                        {"column_type": "DOUBLE", "value": 10.0},
+                        {"column_type": "DOUBLE", "value": 0.0},
+                    ]
+                },
+            ],
+        },
+    }
+
+    response = await http_request(
+        ops_test, "POST", f"{base_url}/_plugins/_ml/_train_predict/kmeans", payload
+    )
+    assert response.get("status") == "COMPLETED", "ML run did not complete"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_observability_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that PPL queries can be interpreted for the observability plugin."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    # send PPL query
+    payload = {"query": f"source = {TEST_INDEX}"}
+    response = await http_request(ops_test, "POST", f"{base_url}/_plugins/_ppl", payload)
+    assert response.get("size") == len(TEST_DOCS)
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_flow_framework_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the flow framework plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    endpoint = f"{base_url}/_plugins/_flow_framework/workflow"
+
+    # delete TEST_INDEX (the workflow will recreate it)
+    await delete_index(ops_test, APP_NAME, leader_unit_ip, TEST_INDEX)
+
+    # register model group
+    ml_endpoint = f"{base_url}/_plugins/_ml"
+    payload = {"name": "test_group", "description": "Test model group"}
+    response = await http_request(
+        ops_test, "POST", f"{ml_endpoint}/model_groups/_register", payload
+    )
+    model_group_id = response.get("model_group_id")
+    assert model_group_id, "Model group not created"
+
+    # register model
+    payload = TEXT_EMBEDDING_MODEL | {"model_group_id": model_group_id}
+    response = await http_request(ops_test, "POST", f"{ml_endpoint}/models/_register", payload)
+    task_id = response.get("task_id")
+    assert task_id, "Model registration task not created"
+
+    # poll until model registered
+    logger.info("Waiting for model registration to complete...")
+    assert await poll_until(
+        ops_test,
+        f"{ml_endpoint}/tasks/{task_id}",
+        lambda status: status.get("state") == "COMPLETED",
+    ), "ML model registration did not complete before timeout"
+
+    # get model id
+    response = await http_request(ops_test, "GET", f"{ml_endpoint}/tasks/{task_id}")
+    model_id = response.get("model_id")
+    assert model_id, "Model not created"
+
+    # create semantic search workflow
+    payload = {
+        "create_ingest_pipeline.pipeline_id": INGEST_PIPELINE_ID,
+        "create_ingest_pipeline.model_id": model_id,
+        "create_index.name": TEST_INDEX,
+        "text_embedding.field_map.output.dimension": TEXT_EMBEDDING_OUTPUT_DIM,
+    }
+    response = await http_request(
+        ops_test, "POST", f"{endpoint}?use_case=semantic_search&provision=true", payload
+    )
+    workflow_id = response.get("workflow_id")
+    assert workflow_id, "Workflow not created"
+
+    logger.info("Waiting for flow framework workflow to complete...")
+    assert await poll_until(
+        ops_test,
+        f"{endpoint}/{workflow_id}/_status",
+        lambda workflow: workflow.get("state") == "COMPLETED",
+    )
+
+    # check if index was created
+    resp_code = await http_request(
+        ops_test, "GET", f"{base_url}/{TEST_INDEX}", resp_status_code=True
+    )
+    assert resp_code == 200, "Flow framework did not create index"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_neural_search_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the neural search plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    # get model id used for ingesting documents to this index
+    # ingest pipeline with id {INGEST_PIPELINE_ID} was created during flow framework test
+    response = await http_request(
+        ops_test, "GET", f"{base_url}/_ingest/pipeline/{INGEST_PIPELINE_ID}"
+    )
+    processors = response.get(INGEST_PIPELINE_ID).get("processors", [])
+    assert len(processors) > 0
+    model_id = processors[0].get("text_embedding").get("model_id")
+    assert model_id, "Could not find model for neural search"
+
+    # deploy model
+    response = await http_request(
+        ops_test, "POST", f"{base_url}/_plugins/_ml/models/{model_id}/_deploy"
+    )
+    task_id = response.get("task_id")
+    assert task_id, "Model deployment task not created"
+
+    # poll until model deployment complete
+    logger.info("Waiting for model deployment to complete...")
+    assert await poll_until(
+        ops_test,
+        f"{base_url}/_plugins/_ml/tasks/{task_id}",
+        lambda status: status.get("state") == "COMPLETED",
+    )
+
+    # insert docs
+    await bulk_insert(ops_test, APP_NAME, leader_unit_ip, bulk_encode(TEST_DOCS, TEST_INDEX))
+    await http_request(ops_test, "POST", f"{base_url}/{TEST_INDEX}/_refresh")
+
+    # run neural search
+    payload = {
+        "query": {"neural": {"passage_embedding": {"query_text": "hello", "model_id": model_id}}}
+    }
+    response = await http_request(ops_test, "GET", f"{base_url}/{TEST_INDEX}/_search", payload)
+    assert len(response.get("hits", {}).get("hits", [])) > 0, "Neural search did not yield results"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_ltr_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the learning-to-rank plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    endpoint = f"{base_url}/_ltr/_featureset"
+
+    # initialize default feature store
+    response = await http_request(ops_test, "PUT", f"{base_url}/_ltr")
+    assert response.get("acknowledged"), "LTR index not created"
+
+    # create feature set
+    featureset = "test-featureset"
+    feature = "test-feature"
+    payload = {
+        "featureset": {
+            "features": [
+                {
+                    "name": feature,
+                    "params": ["q"],
+                    "template_language": "mustache",
+                    "template": {"match": {"passage_text": "{{q}}"}},
+                }
+            ]
+        }
+    }
+    response = await http_request(ops_test, "POST", f"{endpoint}/{featureset}", payload)
+    assert response.get("result") == "created", "Feature set not created"
+
+    # create model using the featureset to score
+    model = "test-lm"
+    payload = {
+        "model": {
+            "name": model,
+            "model": {"type": "model/linear", "definition": {feature: 1.0}},
+        }
+    }
+    response = await http_request(
+        ops_test,
+        "POST",
+        f"{base_url}/_ltr/_featureset/{featureset}/_createmodel",
+        payload,
+    )
+    logger.info(f"LTR model creation response: {response}")
+    assert response.get("result") == "created", "LTR model not created"
+
+    # learn ranking with model
+    payload = {
+        "query": {"match_all": {}},
+        "rescore": [
+            {
+                "window_size": 10,
+                "query": {"rescore_query": {"sltr": {"model": model, "params": {"q": "planet"}}}},
+            }
+        ],
+        "size": 1,
+    }
+    response = await http_request(ops_test, "POST", f"{base_url}/{TEST_INDEX}/_search", payload)
+    logger.info(f"LTR search response: {response}")
+    assert (
+        len(response.get("hits", {}).get("hits", [])) == 1
+    ), "Scoring with LTR did not yield a result"
+    await delete_index(ops_test, APP_NAME, leader_unit_ip, TEST_INDEX)
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_security_analytics_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the security analytics plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    endpoint = f"{base_url}/_plugins/_security_analytics"
+
+    # add custom rule to select doc with activity = suspicious
+    sigma_rule = """
+title: Critical Detector
+id: 11111111-2222-3333-4444-555555555555
+description: Detect docs where region == west
+status: experimental
+author: superadmin
+date: 2025/08/27
+logsource:
+  product: linux
+detection:
+  select:
+    activity: "suspicious"
+  condition: select
+level: low"""
+    response = await http_request(
+        ops_test, "POST", f"{endpoint}/rules?category=linux", payload=sigma_rule
+    )
+    rule_id = response.get("_id")
+    assert rule_id, "Rule not created"
+
+    log_index = "log-index"
+    await create_index(
+        ops_test,
+        APP_NAME,
+        leader_unit_ip,
+        log_index,
+        extra_mappings={
+            "properties": {
+                "activity": {"type": "keyword"},
+                "name": {"type": "keyword"},
+            }
+        },
+    )
+
+    # create detector
+    payload = {
+        "enabled": True,
+        "name": "danger-detector",
+        "detector_type": "linux",
+        "schedule": {"period": {"interval": 1, "unit": "MINUTES"}},
+        "inputs": [
+            {
+                "detector_input": {
+                    "indices": [log_index],
+                    "custom_rules": [{"id": rule_id}],
+                }
+            }
+        ],
+    }
+    response = await http_request(ops_test, "POST", f"{endpoint}/detectors", payload)
+    logger.info(f"\nDetectors response: {response}")
+    detector_id = response.get("_id")
+    assert detector_id, "Security Analytics detector not created"
+
+    docs = [
+        {"name": "a", "activity": "not suspicious"},
+        {"name": "b", "activity": "very normal"},
+        {"name": "c", "activity": "suspicious"},
+    ]
+    await bulk_insert(ops_test, APP_NAME, leader_unit_ip, bulk_encode(docs, log_index))
+    await http_request(ops_test, "POST", f"{base_url}/{log_index}/_refresh")
+
+    logger.info("Waiting for detector schedule period to pass...")
+    await asyncio.sleep(60)
+
+    # check for findings
+    logger.info("Waiting for security analytics finding to be reported...")
+    assert await poll_until(
+        ops_test,
+        f"{endpoint}/findings/_search?detector_id={detector_id}",
+        lambda findings: findings.get("total_findings") == 1,
+        timeout=60 * 3,
+    )
+    await http_request(ops_test, "DELETE", f"{endpoint}/detectors/{detector_id}")
+    await http_request(ops_test, "DELETE", f"{endpoint}/rules/{rule_id}?category=linux")
+    await delete_index(ops_test, APP_NAME, leader_unit_ip, log_index)
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_custom_codecs_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the custom codecs plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    # create index with zstd codec
+    zstd = "zstd-index"
+    default = "default-index"
+    await create_index(
+        ops_test, APP_NAME, leader_unit_ip, zstd, extra_index_settings={"codec": "zstd"}
+    )
+    await create_index(ops_test, APP_NAME, leader_unit_ip, default)
+
+    # insert same docs to indices with different codecs
+    docs = [{"x": i, "blob": "A" * 100} for i in range(5000)]
+    body = bulk_encode(docs, zstd) + "\n" + bulk_encode(docs, default)
+    await bulk_insert(ops_test, APP_NAME, leader_unit_ip, body)
+
+    # refresh so store size reflects indexed data
+    await http_request(ops_test, "POST", f"{base_url}/{zstd},{default}/_refresh")
+
+    # Force merge segments so compression is applied (zstd codec compresses during merges)
+    await http_request(
+        ops_test,
+        "POST",
+        f"{base_url}/{zstd},{default}/_forcemerge?max_num_segments=1&wait_for_completion=true",
+    )
+
+    response = await http_request(
+        ops_test, "GET", f"{base_url}/{zstd}/_settings?flat_settings=true"
+    )
+    codec = response[zstd]["settings"]["index.codec"]
+    assert codec == "zstd", f"Expected codec 'zstd' but found {codec}"
+
+    # compare size of indices, zstd should be smaller or equal
+    # This test was flaky due to two reasons:
+    # 1. Compression happens during segment merges, not immediately after indexing.
+    #    Without force merge, unmerged segments could make zstd appear
+    #    larger than default (e.g., 147474 > 416).
+    #    Fixed by forcing merges before comparing sizes.
+    # 2. For very small datasets, fixed overhead (metadata, segment headers, minimum segment sizes)
+    #    may dominate, making compressed and uncompressed sizes equal (e.g., 416 == 416).
+    #    Fixed by using <= instead of < to allow equality for edge cases.
+    stats = await http_request(ops_test, "GET", f"{base_url}/{zstd},{default}/_stats/store")
+    zstd_size = stats["indices"][zstd]["total"]["store"]["size_in_bytes"]
+    default_size = stats["indices"][default]["total"]["store"]["size_in_bytes"]
+
+    logger.info(f"Index sizes - zstd: {zstd_size} default: {default_size}")
+    assert (
+        zstd_size > 0 and default_size > 0
+    ), "Index store sizes should be positive after bulk indexing"
+    assert (
+        zstd_size <= default_size
+    ), f"zstd codec should not increase size: zstd={zstd_size} default={default_size}"
+    await delete_index(ops_test, APP_NAME, leader_unit_ip, zstd)
+    await delete_index(ops_test, APP_NAME, leader_unit_ip, default)
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_geospatial_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the geospatial plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    endpoint = f"{base_url}/_plugins/geospatial/ip2geo/datasource"
+
+    # create data source
+    datasource = "cities"
+    manifest_url = "https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json"
+    payload = {
+        "endpoint": manifest_url,
+        "update_interval_in_days": 3,
+    }
+    success = await http_request(ops_test, "PUT", f"{endpoint}/{datasource}", payload)
+    assert success, "Could not download Geospatial data source manifest"
+
+    # wait for data source to download
+    logger.info("Waiting for data to be available...")
+    assert await poll_until(
+        ops_test,
+        f"{endpoint}/{datasource}",
+        lambda ds: ds["datasources"][0]["state"] == "AVAILABLE",
+        timeout=60 * 5,
+        interval=10,
+    ), "Geo data not available before timeout"
+
+    geo_pipeline = "geo-pipeline"
+    payload = {"processors": [{"ip2geo": {"field": "ip", "datasource": datasource}}]}
+    await http_request(ops_test, "PUT", f"{base_url}/_ingest/pipeline/{geo_pipeline}", payload)
+
+    # get geo-enriched data
+    payload = {"docs": [{"_index": "testindex1", "_id": "1", "_source": {"ip": "172.0.0.1"}}]}
+    response = await http_request(
+        ops_test,
+        "POST",
+        f"{base_url}/_ingest/pipeline/{geo_pipeline}/_simulate",
+        payload,
+    )
+    logger.info(f"Geospatial response: {response}")
+
+    # ensure geo enriched data exists
+    enriched_documents = response.get("docs", [])
+    assert len(enriched_documents) > 0, "No geo-enriched documents found"
+    assert enriched_documents[0]["doc"]["_source"]["ip2geo"], "No geo-enriched data found"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_skills_plugin(ops_test: OpsTest, deploy_type: str) -> None:
+    """Test that the skills plugin is enabled and functional."""
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+    endpoint = f"{base_url}/_plugins/_ml/agents"
+
+    # register flow agent to run CatIndexTool
+    payload = {
+        "name": "skills_test",
+        "type": "flow",
+        "tools": [{"type": "CatIndexTool", "name": "list"}],
+    }
+    response = await http_request(ops_test, "POST", f"{endpoint}/_register", payload)
+    agent_id = response.get("agent_id")
+    assert agent_id, "Flow agent not created"
+
+    # run the agent
+    payload = {"parameters": {"question": "How many indices do I have?"}}
+
+    response = await http_request(ops_test, "POST", f"{endpoint}/{agent_id}/_execute", payload)
+    assert len(response.get("inference_results", [])) > 0, "Flow agent did not return any results"
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
+async def test_smtp_relation_when_related_with_smtp_integrator_then_creates_notifications(
+    ops_test: OpsTest, deploy_type: str
+) -> None:
+    """Ensure that relating smtp-integrator results in notifications email config objects:
+
+    - SMTP sender/account config
+    - Email channel config
+    - Email group config
+    """
+    # ensure OpenSearch is up
+    await _wait_for_units(ops_test, deploy_type)
+
+    # deploy smtp-integrator
+    await ops_test.model.deploy(
+        SMTP_INTEGRATOR_APP_NAME,
+        channel=SMTP_INTEGRATOR_CHANNEL,
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[SMTP_INTEGRATOR_APP_NAME],
+        timeout=20 * 60,
+    )
+
+    # dummy SMTP config
+    await ops_test.model.applications[SMTP_INTEGRATOR_APP_NAME].set_config(
+        {
+            "host": "127.0.0.1",
+            "port": "2525",
+            "user": "dummy-user",
+            "password": "dummy-pass",
+            "transport_security": "none",
+            "auth_type": "plain",
+            "smtp_sender": "no-reply@example.com",
+            "recipients": "a@example.com,b@example.com",
+        }
+    )
+
+    # relate opensearch and smtp
+    await ops_test.model.integrate(f"{APP_NAME}:smtp", f"{SMTP_INTEGRATOR_APP_NAME}:smtp")
+    await _wait_for_units(ops_test, deploy_type)
+
+    leader_unit_ip = await get_leader_unit_ip(ops_test)
+    base_url = f"https://{leader_unit_ip}:9200"
+
+    relation_id = _get_relation_id(
+        ops_test.model,
+        f"{APP_NAME}:smtp",
+        f"{SMTP_INTEGRATOR_APP_NAME}:smtp",
+    )
+
+    smtp_sender_cfg_name = f"smtp-{relation_id}_smtp-account"
+    email_channel_cfg_name = f"smtp-{relation_id}_email-channel"
+    email_group_cfg_name = f"smtp-{relation_id}_recipients"
+
+    sender_cfg = await _wait_until_config_present(ops_test, base_url, smtp_sender_cfg_name)
+    channel_cfg = await _wait_until_config_present(ops_test, base_url, email_channel_cfg_name)
+    group_cfg = await _wait_until_config_present(ops_test, base_url, email_group_cfg_name)
+
+    assert _cfg_name(sender_cfg) == smtp_sender_cfg_name
+    assert _cfg_name(channel_cfg) == email_channel_cfg_name
+    assert _cfg_name(group_cfg) == email_group_cfg_name
+
+    # remove relation
+    main_app = ops_test.model.applications[APP_NAME]
+
+    await main_app.remove_relation(
+        f"{APP_NAME}:smtp",
+        f"{SMTP_INTEGRATOR_APP_NAME}:smtp",
+    )
+    await _wait_for_units(ops_test, deploy_type)
+
+    # now they should be deleted
+    await _wait_until_config_absent(ops_test, base_url, email_channel_cfg_name)
+    await _wait_until_config_absent(ops_test, base_url, email_group_cfg_name)
+    await _wait_until_config_absent(ops_test, base_url, smtp_sender_cfg_name)

--- a/tests/spread/vm/test_plugins.py-small/task.yaml
+++ b/tests/spread/vm/test_plugins.py-small/task.yaml
@@ -1,0 +1,9 @@
+summary: test_plugins.py
+environment:
+  TEST_MODULE: plugins/test_plugins.py
+systems:
+  - self-hosted-linux-amd64-noble-xlarge
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results" -m 'group(id="small_deployment")'
+artifacts:
+  - allure-results


### PR DESCRIPTION
# Key changes

## Plugins

* Ported plugin manager.
* Ported plugin events handler. However, the whole purpose of this events handler is to handle large deployments and while we don't support them, it is non-functional.
* The `get_object` & `put_object` functions were moved from `ApplicationState` to the `RelationState` base class in order to bring that functionality to both application & server contexts. It is used by `plugin_config_info` state property.
* Added plugins integration test with large deployments & COS (#33) tests skipped due to missing support.

## Notifications

* Ported notifications manager & events handler.
* Added SMTP charm library, on which notifications are dependent.
* Added smtp interface in the `tests/charms/opensearch_test_charm/metadata.yaml`.

## Keystore

* Ported keystore manager & events handler.
* Added `opensearch_keystore` path to the workload's `Paths`.