### PR TITLE
patch: [DPE-9177] [DPE-9176] Port JWT & OAuth

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up environment
         run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs

--- a/opensearch_single_kernel/charmcraft.yaml
+++ b/opensearch_single_kernel/charmcraft.yaml
@@ -18,3 +18,5 @@ bases:
 charm-libs:
   - lib: grafana_agent.cos_agent
     version: "0"
+  - lib: hydra.oauth
+    version: "0"

--- a/opensearch_single_kernel/charms/base.py
+++ b/opensearch_single_kernel/charms/base.py
@@ -31,8 +31,10 @@ from opensearch_single_kernel.events.custom_events import (
 from opensearch_single_kernel.events.external_clients import (
     ExternalClientsEventsHandler,
 )
+from opensearch_single_kernel.events.jwt import JWTEventsHandler
 from opensearch_single_kernel.events.keystore import KeystoreEventsHandler
 from opensearch_single_kernel.events.notifications import NotificationsEvents
+from opensearch_single_kernel.events.oauth import OAuthEventsHandler
 from opensearch_single_kernel.events.opensearch import OpenSearchEventsHandler
 from opensearch_single_kernel.events.tls import TLSEventsHandler
 from opensearch_single_kernel.managers.cluster import ClusterManager
@@ -90,6 +92,8 @@ class OpenSearchBaseCharm(ops.CharmBase, ABC):
         self.keystore_events = KeystoreEventsHandler(self)
         self.notifications_events = NotificationsEvents(self)
         self.cos_events = CosEventsHandler(self)
+        self.jwt_events = JWTEventsHandler(self)
+        self.oauth_events = OAuthEventsHandler(self)
 
     def trigger_peer_rel_changed(
         self,

--- a/opensearch_single_kernel/common/client.py
+++ b/opensearch_single_kernel/common/client.py
@@ -805,7 +805,7 @@ class OpenSearchClient:
                     request_kwargs = {
                         "method": method.upper(),
                         "url": url,
-                        "verify": f"{self.workload.paths.certs}/chain.pem",
+                        "verify": self.workload.paths.certs_chain.as_posix(),
                         "headers": {
                             "Accept": "application/json",
                             "Content-Type": "application/json",

--- a/opensearch_single_kernel/common/constants.py
+++ b/opensearch_single_kernel/common/constants.py
@@ -205,6 +205,12 @@ KEYTOOL = "opensearch.keytool"
 OLD_CA_PREFIX = "old-"
 CERTS_EXPIRATION_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
+# OAuth
+OAUTH_CLIENT_AUDIENCE = ["opensearch"]
+OAUTH_CLIENT_REDIRECT_URI = "http://opensearch.local"
+OAUTH_CLIENT_SCOPE = "openid email profile"
+OAUTH_CLIENT_GRANT_TYPES = ["client_credentials"]
+
 
 # OpenSearch Protected Indices
 PROTECTED_INDEX_NAMES = [

--- a/opensearch_single_kernel/common/constants.py
+++ b/opensearch_single_kernel/common/constants.py
@@ -235,6 +235,8 @@ PEER_CLUSTER_ORCHESTRATOR_RELATION = "peer-cluster-orchestrator"
 PEER_CLUSTER_RELATION = "peer-cluster"
 CLIENT_RELATION = "opensearch-client"
 COS_RELATION = "cos-agent"
+JWT_CONFIG_RELATION = "jwt-configuration"
+OAUTH_RELATION = "oauth"
 
 
 # Paths

--- a/opensearch_single_kernel/common/statuses.py
+++ b/opensearch_single_kernel/common/statuses.py
@@ -62,6 +62,9 @@ class CharmStatuses(Enum):
 
     # Security Index
     SECURITY_INDEX_INIT_IN_PROGRESS = MaintenanceStatus("Initializing the security index...")
+    SECURITY_INDEX_UPDATE_ERROR = BlockedStatus(
+        "Failed to update security configuration, check logs for details."
+    )
 
     # Start
     SERVICE_START_ERROR = BlockedStatus(
@@ -117,3 +120,16 @@ class CharmStatuses(Enum):
         "Parameters missing from smtp-integrator: {params}."
     )
     SMTP_COULD_NOT_READ_DATA = BlockedStatus("Could not read smtp relation data: {exc}.")
+
+    # JWT
+    JWT_RELATION_INVALID = BlockedStatus(
+        "JWT relation must be created with Main-cluster-orchestrator."
+    )
+    JWT_AUTH_CONFIG_INVALID = BlockedStatus(
+        "Configuration for JWT authentication is invalid. Check and correct parameters."
+    )
+
+    # OAuth
+    OAUTH_RELATION_INVALID = BlockedStatus(
+        "OAuth relation must be created with Main-cluster-orchestrator"
+    )

--- a/opensearch_single_kernel/core/models.py
+++ b/opensearch_single_kernel/core/models.py
@@ -406,3 +406,16 @@ class SmtpConfig:
     group_id: str
     channel_id: str
     transport_security: SmtpTransportSecurity
+
+
+class JWTAuthConfiguration(Model):
+    """Model class for the configuration parameters of JWT authentication."""
+
+    signing_key: str
+    jwt_header: str | None = None
+    jwt_url_parameter: str | None = None
+    roles_key: str
+    subject_key: str | None = None
+    required_audience: str | None = None
+    required_issuer: str | None = None
+    jwt_clock_skew_tolerance_seconds: int | None = None

--- a/opensearch_single_kernel/core/relations.py
+++ b/opensearch_single_kernel/core/relations.py
@@ -278,3 +278,14 @@ class PeerCluster(RelationState):
 
     def __init__(self, relation, data_interface, component):
         super().__init__(relation, data_interface, component)
+
+
+class JwtData(RequirerData):
+    """Data Interface to JWT relation on requirer side."""
+
+    def __init__(self, model, relation_name: str):
+        super().__init__(
+            model,
+            relation_name,
+            additional_secret_fields=["signing-key"],
+        )

--- a/opensearch_single_kernel/core/state.py
+++ b/opensearch_single_kernel/core/state.py
@@ -16,8 +16,10 @@ from ops import Application, JujuVersion, Object, Relation, Unit
 from opensearch_single_kernel.common.constants import (
     CLIENT_RELATION,
     GENERATED_ROLES,
+    JWT_CONFIG_RELATION,
     KIBANA_SERVER_ROLE,
     NODE_LOCK_RELATION,
+    OAUTH_RELATION,
     OPENSEARCH_HTTP_PORT,
     PEER_CLUSTER_ORCHESTRATOR_RELATION,
     PEER_CLUSTER_RELATION,
@@ -32,6 +34,7 @@ from opensearch_single_kernel.common.constants import (
 from opensearch_single_kernel.core.models import (
     DeploymentDescription,
     DeploymentType,
+    JWTAuthConfiguration,
     Node,
     OpenSearchProfile,
     PeerClusterApp,
@@ -41,6 +44,7 @@ from opensearch_single_kernel.core.models import (
     TestingProfile,
 )
 from opensearch_single_kernel.core.relations import (
+    JwtData,
     PeerCluster,
     PeerClusterData,
     PeerClusterOrchestratorData,
@@ -52,6 +56,7 @@ from opensearch_single_kernel.lib.charms.data_platform_libs.v0.data_interfaces i
     DataPeerData,
     DataPeerUnitData,
     OpenSearchProvidesData,
+    SecretGroup,
 )
 from opensearch_single_kernel.utils.helpers import (
     format_unit_name,
@@ -69,7 +74,10 @@ class OpenSearchServer(RelationState):
     """State/Relation data collection for an opensearch unit"""
 
     def __init__(
-        self, relation: Relation | None, data_interface: DataPeerUnitData, component: Unit
+        self,
+        relation: Relation | None,
+        data_interface: DataPeerUnitData,
+        component: Unit,
     ):
         super().__init__(relation, data_interface, component)
         self.unit = component
@@ -232,6 +240,49 @@ class OpenSearchServer(RelationState):
             return
         self.put_object("plugin_config_info", value)
 
+    @property
+    def jwt_auth_configuration(self) -> JWTAuthConfiguration | None:
+        """Return JWT auth configuration if any."""
+        if not (config := self.get_object("jwt-auth-configuration")):
+            return None
+        return JWTAuthConfiguration.from_dict(config)
+
+    @jwt_auth_configuration.setter
+    def jwt_auth_configuration(self, value: JWTAuthConfiguration | None) -> None:
+        """Set or remove JWT auth configuration."""
+        if value is None:
+            self.update({"jwt-auth-configuration": ""})
+        else:
+            self.put_object("jwt-auth-configuration", value.to_dict())
+
+    @property
+    def oauth_openid_connect_url(self) -> str | None:
+        """Return OAuth openid_connect_url if configured."""
+        return self.relation_data.get("oauth_openid_connect_url")
+
+    @oauth_openid_connect_url.setter
+    def oauth_openid_connect_url(self, value: str | None) -> None:
+        """Set or remove OAuth openid_connect_url."""
+        self.update({"oauth_openid_connect_url": value or ""})
+
+    @property
+    def oauth_departing(self) -> bool:
+        """Return whether oauth relation broken event should be skipped.
+
+        When current leader is unit oauth relation isn't breaking
+        even if unit receives oauth relation broken event.
+        """
+        return self.relation_data.get("oauth_departing", "") == "True"
+
+    @oauth_departing.setter
+    def oauth_departing(self, value: bool):
+        """Set whether oauth relation broken event should be skipped.
+
+        When current leader is unit oauth relation isn't breaking
+        even if unit receives oauth relation broken event.
+        """
+        self.update({"oauth_departing": str(value)})
+
 
 class OpenSearchApplication(RelationState):
     """An OpenSearch Application is a charm application with a given role.
@@ -241,7 +292,10 @@ class OpenSearchApplication(RelationState):
     """
 
     def __init__(
-        self, relation: Relation | None, data_interface: DataPeerData, component: Application
+        self,
+        relation: Relation | None,
+        data_interface: DataPeerData,
+        component: Application,
     ):
         super().__init__(relation, data_interface, component)
         self.app = component
@@ -366,7 +420,9 @@ class OpenSearchApplication(RelationState):
     def is_data_role_in_cluster_fleet_apps(self) -> bool:
         """Look for data-role through all the roles of all the nodes in all applications"""
         data_apps_in_fleet = [app for app in self.apps_in_fleet() if "data" in app.roles]
-        return data_apps_in_fleet and any(app.planned_units > 0 for app in data_apps_in_fleet)
+        return bool(data_apps_in_fleet) and any(
+            app.planned_units > 0 for app in data_apps_in_fleet
+        )
 
     @property
     def client_users_dict(self) -> dict[str, str]:
@@ -487,6 +543,41 @@ class ExternalOpenSearchClient(RelationState):
     def extra_user_roles(self, roles: str) -> None:
         """Set the extra user roles for this relation."""
         self.update({"extra-user-roles": roles})
+
+
+class JwtState(RelationState):
+    """State for the JWT relation data."""
+
+    def is_related_secret_label(self, label: str | None) -> bool:
+        """Check whether provided secret label is related to this relation."""
+        return (
+            label
+            == self.data_interface._generate_secret_label(
+                relation.name, relation.id, SecretGroup("extra")
+            )
+            if label is not None
+            and (relation := self.data_interface._relation_from_secret_label(label))
+            else False
+        )
+
+    @property
+    def auth_configuration(self) -> JWTAuthConfiguration:
+        """Build a JWT auth configuration from the relation data.
+
+        Might throw a validation exception.
+        """
+        return JWTAuthConfiguration(
+            signing_key=self.relation_data.get("signing-key", ""),
+            jwt_header=self.relation_data.get("jwt-header"),
+            jwt_url_parameter=self.relation_data.get("jwt-url-parameter"),
+            roles_key=self.relation_data.get("roles-key", ""),
+            subject_key=self.relation_data.get("subject-key"),
+            required_audience=self.relation_data.get("required-audience"),
+            required_issuer=self.relation_data.get("required-issuer"),
+            jwt_clock_skew_tolerance_seconds=self.relation_data.get(
+                "jwt-clock-skew-tolerance-seconds"
+            ),
+        )
 
 
 class ClusterState(Object):
@@ -920,3 +1011,22 @@ class ClusterState(Object):
                 for app in cluster_fleet_apps
             )
         )
+
+    @property
+    def jwt_relation(self) -> Relation | None:
+        """Get JWT relation."""
+        return self.model.get_relation(JWT_CONFIG_RELATION)
+
+    @property
+    def jwt(self) -> JwtState:
+        """Get JWT state."""
+        return JwtState(
+            relation=self.jwt_relation,
+            data_interface=JwtData(self.model, JWT_CONFIG_RELATION),
+            component=self.model.app,
+        )
+
+    @property
+    def oauth_relation(self) -> Relation | None:
+        """Get OAuth relation."""
+        return self.model.get_relation(OAUTH_RELATION)

--- a/opensearch_single_kernel/core/state.py
+++ b/opensearch_single_kernel/core/state.py
@@ -248,12 +248,14 @@ class OpenSearchServer(RelationState):
         return JWTAuthConfiguration.from_dict(config)
 
     @jwt_auth_configuration.setter
-    def jwt_auth_configuration(self, value: JWTAuthConfiguration | None) -> None:
-        """Set or remove JWT auth configuration."""
-        if value is None:
-            self.update({"jwt-auth-configuration": ""})
-        else:
-            self.put_object("jwt-auth-configuration", value.to_dict())
+    def jwt_auth_configuration(self, value: JWTAuthConfiguration) -> None:
+        """Update JWT auth configuration."""
+        self.put_object("jwt-auth-configuration", value.to_dict())
+
+    @jwt_auth_configuration.deleter
+    def jwt_auth_configuration(self) -> None:
+        """Remove JWT auth configuration."""
+        self.update({"jwt-auth-configuration": ""})
 
     @property
     def oauth_openid_connect_url(self) -> str | None:

--- a/opensearch_single_kernel/events/jwt.py
+++ b/opensearch_single_kernel/events/jwt.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for events handler related to OpenSearch JWT authentication configuration."""
@@ -79,7 +79,7 @@ class JWTEventsHandler(Object):
                 self.charm.status.clear(CharmStatuses.JWT_RELATION_INVALID, app=True)
             return
 
-        self.charm.state.server.jwt_auth_configuration = None
+        del self.charm.state.server.jwt_auth_configuration
         self.charm.config_manager.update_security_config()
 
         self.apply_security_config_if_needed(event)

--- a/opensearch_single_kernel/events/jwt.py
+++ b/opensearch_single_kernel/events/jwt.py
@@ -1,0 +1,154 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module for events handler related to OpenSearch JWT authentication configuration."""
+
+import logging
+from typing import TYPE_CHECKING
+
+from ops import (
+    EventBase,
+    Object,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+    SecretChangedEvent,
+)
+from pydantic.error_wrappers import ValidationError
+
+from opensearch_single_kernel.common.constants import (
+    JWT_CONFIG_RELATION,
+    CertType,
+    Scope,
+)
+from opensearch_single_kernel.common.exceptions import OpenSearchCmdError
+from opensearch_single_kernel.common.statuses import CharmStatuses
+from opensearch_single_kernel.core.models import DeploymentType
+
+if TYPE_CHECKING:
+    from opensearch_single_kernel.charms.base import OpenSearchBaseCharm
+
+logger = logging.getLogger(__name__)
+
+
+class JWTEventsHandler(Object):
+    """Handler for managing JWT relations."""
+
+    def __init__(self, charm: "OpenSearchBaseCharm") -> None:
+        super().__init__(charm, "jwt")
+        self.charm = charm
+
+        self.framework.observe(self.charm.on.secret_changed, self._on_secret_changed)
+        self.framework.observe(
+            self.charm.on[JWT_CONFIG_RELATION].relation_created,
+            self._on_jwt_relation_created,
+        )
+        self.framework.observe(
+            self.charm.on[JWT_CONFIG_RELATION].relation_changed,
+            self._on_jwt_relation_changed,
+        )
+        self.framework.observe(
+            self.charm.on[JWT_CONFIG_RELATION].relation_broken,
+            self._on_jwt_relation_broken,
+        )
+
+    def _on_jwt_relation_created(self, _: RelationCreatedEvent) -> None:
+        """Handle relation creation."""
+        if (
+            deployment_desc := self.charm.state.application.deployment_desc
+        ) and deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            # in large deployments, JWT configuration must only be handled by the main orchestrator
+            # this is a safeguard to avoid different sources for applying security configuration
+            if self.charm.unit.is_leader():
+                self.charm.status.set(CharmStatuses.JWT_RELATION_INVALID, app=True)
+
+    def _on_jwt_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handle changed relation data."""
+        if not self.charm.state.jwt.relation:
+            logger.error(f"Cannot access relation data for {JWT_CONFIG_RELATION}")
+            return
+
+        self._validate_and_apply_jwt_auth_config(event)
+
+    def _on_jwt_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle the removal of the relation."""
+        if (
+            deployment_desc := self.charm.state.application.deployment_desc
+        ) and deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            if self.charm.unit.is_leader():
+                self.charm.status.clear(CharmStatuses.JWT_RELATION_INVALID, app=True)
+            return
+
+        self.charm.state.server.jwt_auth_configuration = None
+        self.charm.config_manager.update_security_config()
+
+        self.apply_security_config_if_needed(event)
+
+    def _on_secret_changed(self, event: SecretChangedEvent) -> None:
+        """Handle changed secret data."""
+        if not self.charm.state.jwt.relation:
+            return
+
+        if not self.charm.state.jwt.is_related_secret_label(event.secret.label):
+            logger.debug("Updated secret not relevant")
+            return
+
+        self._validate_and_apply_jwt_auth_config(event)
+
+    def _validate_and_apply_jwt_auth_config(self, event: EventBase) -> None:
+        """Check the provided configuration and apply, if valid."""
+        if (
+            deployment_desc := self.charm.state.application.deployment_desc
+        ) and deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            if self.charm.unit.is_leader():
+                self.charm.status.set(CharmStatuses.JWT_RELATION_INVALID, app=True)
+            return
+
+        if not self.charm.state.application.is_security_index_initialised:
+            logger.debug("Deferring jwt event as security index not initialised yet")
+            event.defer()
+            return
+
+        try:
+            self.charm.state.server.jwt_auth_configuration = (
+                self.charm.state.jwt.auth_configuration
+            )
+        except ValidationError as e:
+            # safety mechanism, this should not happen; config is validated on the jwt-integrator
+            logger.error(f"Validation failed for JWT authentication config: {e}")
+            if self.charm.unit.is_leader():
+                self.charm.status.set(CharmStatuses.JWT_AUTH_CONFIG_INVALID, app=True)
+            return
+
+        if self.charm.unit.is_leader():
+            self.charm.status.clear(CharmStatuses.JWT_AUTH_CONFIG_INVALID, app=True)
+
+        self.charm.config_manager.update_security_config()
+        logger.info("Updated JWT authentication configuration")
+
+        self.apply_security_config_if_needed(event)
+
+    def apply_security_config_if_needed(self, event: EventBase) -> None:
+        """Update Opensearch's security index after updating the JWT auth configuration."""
+        if not self.charm.unit.is_leader():
+            return
+
+        if not (
+            admin_secrets := self.charm.state.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)
+        ):
+            event.defer()
+            return
+
+        try:
+            self.charm.cluster_manager.apply_security_config(
+                admin_secrets, self.charm.config_manager.SECURITY_CONFIG_YML
+            )
+            logger.info("Updated Opensearch security index")
+        except OpenSearchCmdError as e:
+            logger.debug(f"Error when updating the security index: {e.out}")
+            self.charm.status.set(CharmStatuses.SECURITY_INDEX_UPDATE_ERROR, app=True)
+            # we need to come back in this case because there will not be a follow-up event
+            event.defer()
+            return
+
+        self.charm.status.clear(CharmStatuses.SECURITY_INDEX_UPDATE_ERROR, app=True)

--- a/opensearch_single_kernel/events/oauth.py
+++ b/opensearch_single_kernel/events/oauth.py
@@ -14,7 +14,15 @@ from ops import (
     RelationDepartedEvent,
 )
 
-from opensearch_single_kernel.common.constants import OAUTH_RELATION, CertType, Scope
+from opensearch_single_kernel.common.constants import (
+    OAUTH_CLIENT_AUDIENCE,
+    OAUTH_CLIENT_GRANT_TYPES,
+    OAUTH_CLIENT_REDIRECT_URI,
+    OAUTH_CLIENT_SCOPE,
+    OAUTH_RELATION,
+    CertType,
+    Scope,
+)
 from opensearch_single_kernel.common.exceptions import OpenSearchCmdError
 from opensearch_single_kernel.common.statuses import CharmStatuses
 from opensearch_single_kernel.core.models import DeploymentType
@@ -38,10 +46,10 @@ class OAuthEventsHandler(Object):
 
         # NOTE: Placeholder config options, not really needed by Opensearch
         client_config = ClientConfig(
-            audience=["opensearch"],
-            redirect_uri="http://opensearch.local",
-            scope="openid email profile",
-            grant_types=["client_credentials"],
+            audience=OAUTH_CLIENT_AUDIENCE,
+            redirect_uri=OAUTH_CLIENT_REDIRECT_URI,
+            scope=OAUTH_CLIENT_SCOPE,
+            grant_types=OAUTH_CLIENT_GRANT_TYPES,
         )
         self.oauth = OAuthRequirer(self.charm, client_config, relation_name=OAUTH_RELATION)
         self.framework.observe(

--- a/opensearch_single_kernel/events/oauth.py
+++ b/opensearch_single_kernel/events/oauth.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for events handler related to OpenSearch OAuth authentication configuration."""

--- a/opensearch_single_kernel/events/oauth.py
+++ b/opensearch_single_kernel/events/oauth.py
@@ -1,0 +1,161 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module for events handler related to OpenSearch OAuth authentication configuration."""
+
+import logging
+from typing import TYPE_CHECKING
+
+from ops import (
+    EventBase,
+    Object,
+    RelationBrokenEvent,
+    RelationCreatedEvent,
+    RelationDepartedEvent,
+)
+
+from opensearch_single_kernel.common.constants import OAUTH_RELATION, CertType, Scope
+from opensearch_single_kernel.common.exceptions import OpenSearchCmdError
+from opensearch_single_kernel.common.statuses import CharmStatuses
+from opensearch_single_kernel.core.models import DeploymentType
+from opensearch_single_kernel.lib.charms.hydra.v0.oauth import (
+    ClientConfig,
+    OAuthRequirer,
+)
+
+if TYPE_CHECKING:
+    from opensearch_single_kernel.charms.base import OpenSearchBaseCharm
+
+logger = logging.getLogger(__name__)
+
+
+class OAuthEventsHandler(Object):
+    """Handler for managing oauth relations."""
+
+    def __init__(self, charm: "OpenSearchBaseCharm") -> None:
+        super().__init__(charm, "oauth")
+        self.charm = charm
+
+        # NOTE: Placeholder config options, not really needed by Opensearch
+        client_config = ClientConfig(
+            audience=["opensearch"],
+            redirect_uri="http://opensearch.local",
+            scope="openid email profile",
+            grant_types=["client_credentials"],
+        )
+        self.oauth = OAuthRequirer(self.charm, client_config, relation_name=OAUTH_RELATION)
+        self.framework.observe(
+            self.charm.on[OAUTH_RELATION].relation_created,
+            self._on_oauth_relation_created,
+        )
+        self.framework.observe(
+            self.charm.on[OAUTH_RELATION].relation_changed,
+            self._on_oauth_relation_changed,
+        )
+        self.framework.observe(
+            self.charm.on[OAUTH_RELATION].relation_departed,
+            self._on_oauth_relation_departed,
+        )
+        self.framework.observe(
+            self.charm.on[OAUTH_RELATION].relation_broken,
+            self._on_oauth_relation_broken,
+        )
+
+    def _on_oauth_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Handler for `relation_created` event."""
+        if (
+            deployment_desc := self.charm.state.application.deployment_desc
+        ) and deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            # in large deployments, OAuth config must only be handled by the main orchestrator
+            # this is a safeguard to avoid different sources for applying security configuration
+            if self.charm.unit.is_leader():
+                self.charm.status.set(CharmStatuses.OAUTH_RELATION_INVALID, app=True)
+
+    def _on_oauth_relation_changed(self, event: EventBase) -> None:
+        """Handler for `_on_oauth_relation_changed` event.
+
+        Updates the security config.yml with the OIDC info and update the cluster.
+        """
+        if (
+            deployment_desc := self.charm.state.application.deployment_desc
+        ) and deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            # in large deployments, OAuth config must only be handled by the main orchestrator
+            # this is a safeguard to avoid different sources for applying security configuration
+            if self.charm.unit.is_leader():
+                self.charm.status.set(CharmStatuses.OAUTH_RELATION_INVALID, app=True)
+            return
+
+        if not (relation := self.charm.state.oauth_relation):
+            return
+
+        if not relation.data[relation.app]:
+            logger.debug("Oauth relation not yet set up")
+            return
+
+        if not self.charm.state.application.is_security_index_initialised:
+            logger.debug("Deferring oauth relation changed event as cluster is not ready yet")
+            event.defer()
+            return
+
+        self.charm.state.server.oauth_openid_connect_url = (
+            f"{relation.data[relation.app].get('issuer_url')}/.well-known/openid-configuration"
+        )
+        self.charm.config_manager.update_security_config()
+
+        if not self.charm.unit.is_leader():
+            return
+
+        if not (
+            admin_secrets := self.charm.state.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)
+        ):
+            event.defer()
+            return
+
+        try:
+            self.charm.cluster_manager.apply_security_config(
+                admin_secrets, self.charm.config_manager.SECURITY_CONFIG_YML
+            )
+        except OpenSearchCmdError as e:
+            logger.debug(f"Error when updating the security index: {e.out}")
+            event.defer()
+            return
+
+    def _on_oauth_relation_departed(self, event: RelationDepartedEvent) -> None:
+        """Handler for `relation_departed` event."""
+        if event.departing_unit == self.charm.unit and self.charm.state.peer_relation is not None:
+            self.charm.state.server.oauth_departing = True
+
+    def _on_oauth_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handler for `relation_broken` event."""
+        if (
+            deployment_desc := self.charm.state.application.deployment_desc
+        ) and deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            if self.charm.unit.is_leader():
+                self.charm.status.clear(CharmStatuses.OAUTH_RELATION_INVALID, app=True)
+            return
+
+        if (
+            self.charm.state.server.oauth_departing
+            or not self.charm.state.application.is_security_index_initialised
+        ):
+            return
+
+        self.charm.state.server.oauth_openid_connect_url = None
+        self.charm.config_manager.update_security_config()
+
+        if not self.charm.unit.is_leader():
+            return
+
+        if not (
+            admin_secrets := self.charm.state.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)
+        ):
+            event.defer()
+            return
+        try:
+            self.charm.cluster_manager.apply_security_config(
+                admin_secrets, self.charm.config_manager.SECURITY_CONFIG_YML
+            )
+        except OpenSearchCmdError as e:
+            logger.debug(f"Error when updating the security index: {e.out}")
+            event.defer()
+            return

--- a/opensearch_single_kernel/lib/charms/hydra/v0/oauth.py
+++ b/opensearch_single_kernel/lib/charms/hydra/v0/oauth.py
@@ -1,0 +1,813 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""# Oauth Library.
+
+This library is designed to enable applications to register OAuth2/OIDC
+clients with an OIDC Provider through the `oauth` interface.
+
+## Getting started
+
+To get started using this library you just need to fetch the library using `charmcraft`. **Note
+that you also need to add `jsonschema` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.hydra.v0.oauth
+EOF
+```
+
+Then, to initialize the library:
+```python
+# ...
+from charms.hydra.v0.oauth import ClientConfig, OAuthRequirer
+
+OAUTH = "oauth"
+OAUTH_SCOPES = "openid email"
+OAUTH_GRANT_TYPES = ["authorization_code"]
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.oauth = OAuthRequirer(self, client_config, relation_name=OAUTH)
+
+    self.framework.observe(self.oauth.on.oauth_info_changed, self._configure_application)
+    # ...
+
+    def _on_ingress_ready(self, event):
+        self.external_url = "https://example.com"
+        self._set_client_config()
+
+    def _set_client_config(self):
+        client_config = ClientConfig(
+            urljoin(self.external_url, "/oauth/callback"),
+            OAUTH_SCOPES,
+            OAUTH_GRANT_TYPES,
+        )
+        self.oauth.update_client_config(client_config)
+```
+"""
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field, fields
+from typing import Dict, List, Mapping, Optional
+
+import jsonschema
+from ops.charm import (
+    CharmBase,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+)
+from ops.framework import EventBase, EventSource, Handle, Object, ObjectEvents
+from ops.model import Relation, Secret, SecretNotFoundError, TooManyRelatedAppsError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a3a301e325e34aac80a2d633ef61fe97"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 11
+
+PYDEPS = ["jsonschema"]
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "oauth"
+ALLOWED_GRANT_TYPES = [
+    "authorization_code",
+    "refresh_token",
+    "client_credentials",
+    "urn:ietf:params:oauth:grant-type:device_code",
+]
+ALLOWED_CLIENT_AUTHN_METHODS = ["client_secret_basic", "client_secret_post"]
+CLIENT_SECRET_FIELD = "secret"
+
+url_regex = re.compile(
+    r"(^http://)|(^https://)"  # http:// or https://
+    r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|"
+    r"[A-Z0-9-]{2,}\.?)|"  # domain...
+    r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+    r"(?::\d+)?"  # optional port
+    r"(?:/?|[/?]\S+)$",
+    re.IGNORECASE,
+)
+
+OAUTH_PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/oauth/schemas/provider.json",
+    "type": "object",
+    "properties": {
+        "issuer_url": {
+            "type": "string",
+        },
+        "authorization_endpoint": {
+            "type": "string",
+        },
+        "token_endpoint": {
+            "type": "string",
+        },
+        "introspection_endpoint": {
+            "type": "string",
+        },
+        "userinfo_endpoint": {
+            "type": "string",
+        },
+        "jwks_endpoint": {
+            "type": "string",
+        },
+        "scope": {
+            "type": "string",
+        },
+        "client_id": {
+            "type": "string",
+        },
+        "client_secret_id": {
+            "type": "string",
+        },
+        "groups": {"type": "string", "default": None},
+        "ca_chain": {"type": "array", "items": {"type": "string"}, "default": []},
+        "jwt_access_token": {"type": "string", "default": "False"},
+    },
+    "required": [
+        "issuer_url",
+        "authorization_endpoint",
+        "token_endpoint",
+        "introspection_endpoint",
+        "userinfo_endpoint",
+        "jwks_endpoint",
+        "scope",
+    ],
+}
+OAUTH_REQUIRER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/oauth/schemas/requirer.json",
+    "type": "object",
+    "properties": {
+        "redirect_uri": {
+            "type": "string",
+            "default": None,
+        },
+        "audience": {"type": "array", "default": [], "items": {"type": "string"}},
+        "scope": {"type": "string", "default": None},
+        "grant_types": {
+            "type": "array",
+            "default": None,
+            "items": {
+                "enum": ALLOWED_GRANT_TYPES,
+                "type": "string",
+            },
+        },
+        "token_endpoint_auth_method": {
+            "type": "string",
+            "enum": ALLOWED_CLIENT_AUTHN_METHODS,
+            "default": "client_secret_basic",
+        },
+    },
+    "required": ["redirect_uri", "audience", "scope", "grant_types", "token_endpoint_auth_method"],
+}
+
+
+class ClientConfigError(Exception):
+    """Emitted when invalid client config is provided."""
+
+
+class DataValidationError(RuntimeError):
+    """Raised when data validation fails on relation data."""
+
+
+def _load_data(data: Mapping, schema: Optional[Dict] = None) -> Dict:
+    """Parses nested fields and checks whether `data` matches `schema`."""
+    ret = {}
+    for k, v in data.items():
+        try:
+            ret[k] = json.loads(v)
+        except json.JSONDecodeError:
+            ret[k] = v
+
+    if schema:
+        _validate_data(ret, schema)
+    return ret
+
+
+def _dump_data(data: Dict, schema: Optional[Dict] = None) -> Dict:
+    if schema:
+        _validate_data(data, schema)
+
+    ret = {}
+    for k, v in data.items():
+        if isinstance(v, (list, dict)):
+            try:
+                ret[k] = json.dumps(v)
+            except json.JSONDecodeError as e:
+                raise DataValidationError(f"Failed to encode relation json: {e}")
+        elif isinstance(v, bool):
+            ret[k] = str(v)
+        else:
+            ret[k] = v
+    return ret
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    if not isinstance(val, str):
+        raise ValueError(f"invalid value type {type(val)}")
+
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val}")
+
+
+class OAuthRelation(Object):
+    """A class containing helper methods for oauth relation."""
+
+    def _pop_relation_data(self, relation_id: Relation) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        if len(self.model.relations) == 0:
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        if not relation or not relation.app:
+            return
+
+        try:
+            for data in list(relation.data[self.model.app]):
+                relation.data[self.model.app].pop(data, "")
+        except Exception as e:
+            logger.info(f"Failed to pop the relation data: {e}")
+
+
+def _validate_data(data: Dict, schema: Dict) -> None:
+    """Checks whether `data` matches `schema`.
+
+    Will raise DataValidationError if the data is not valid, else return None.
+    """
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+@dataclass
+class ClientConfig:
+    """Helper class containing a client's configuration."""
+
+    redirect_uri: str
+    scope: str
+    grant_types: List[str]
+    audience: List[str] = field(default_factory=lambda: [])
+    token_endpoint_auth_method: str = "client_secret_basic"
+    client_id: Optional[str] = None
+
+    def validate(self) -> None:
+        """Validate the client configuration."""
+        # Validate redirect_uri
+        if not re.match(url_regex, self.redirect_uri):
+            raise ClientConfigError(f"Invalid URL {self.redirect_uri}")
+
+        if self.redirect_uri.startswith("http://"):
+            logger.warning("Provided Redirect URL uses http scheme. Don't do this in production")
+
+        # Validate grant_types
+        for grant_type in self.grant_types:
+            if grant_type not in ALLOWED_GRANT_TYPES:
+                raise ClientConfigError(
+                    f"Invalid grant_type {grant_type}, must be one " f"of {ALLOWED_GRANT_TYPES}"
+                )
+
+        # Validate client authentication methods
+        if self.token_endpoint_auth_method not in ALLOWED_CLIENT_AUTHN_METHODS:
+            raise ClientConfigError(
+                f"Invalid client auth method {self.token_endpoint_auth_method}, "
+                f"must be one of {ALLOWED_CLIENT_AUTHN_METHODS}"
+            )
+
+    def to_dict(self) -> Dict:
+        """Convert object to dict."""
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+@dataclass
+class OauthProviderConfig:
+    """Helper class containing provider's configuration."""
+
+    issuer_url: str
+    authorization_endpoint: str
+    token_endpoint: str
+    introspection_endpoint: str
+    userinfo_endpoint: str
+    jwks_endpoint: str
+    scope: str
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    groups: Optional[str] = None
+    ca_chain: Optional[str] = None
+    jwt_access_token: Optional[bool] = False
+
+    @classmethod
+    def from_dict(cls, dic: Dict) -> "OauthProviderConfig":
+        """Generate OauthProviderConfig instance from dict."""
+        jwt_access_token = False
+        if "jwt_access_token" in dic:
+            jwt_access_token = strtobool(dic["jwt_access_token"])
+        return cls(
+            jwt_access_token=jwt_access_token,
+            **{
+                k: v
+                for k, v in dic.items()
+                if k in [f.name for f in fields(cls)] and k != "jwt_access_token"
+            },
+        )
+
+
+class OAuthInfoChangedEvent(EventBase):
+    """Event to notify the charm that the information in the databag changed."""
+
+    def __init__(self, handle: Handle, client_id: str, client_secret_id: str):
+        super().__init__(handle)
+        self.client_id = client_id
+        self.client_secret_id = client_secret_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "client_id": self.client_id,
+            "client_secret_id": self.client_secret_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        super().restore(snapshot)
+        self.client_id = snapshot["client_id"]
+        self.client_secret_id = snapshot["client_secret_id"]
+
+
+class InvalidClientConfigEvent(EventBase):
+    """Event to notify the charm that the client configuration is invalid."""
+
+    def __init__(self, handle: Handle, error: str):
+        super().__init__(handle)
+        self.error = error
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "error": self.error,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.error = snapshot["error"]
+
+
+class OAuthInfoRemovedEvent(EventBase):
+    """Event to notify the charm that the provider data was removed."""
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        pass
+
+
+class OAuthRequirerEvents(ObjectEvents):
+    """Event descriptor for events raised by `OAuthRequirerEvents`."""
+
+    oauth_info_changed = EventSource(OAuthInfoChangedEvent)
+    oauth_info_removed = EventSource(OAuthInfoRemovedEvent)
+    invalid_client_config = EventSource(InvalidClientConfigEvent)
+
+
+class OAuthRequirer(OAuthRelation):
+    """Register an oauth client."""
+
+    on = OAuthRequirerEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        client_config: Optional[ClientConfig] = None,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._client_config = client_config
+        events = self._charm.on[relation_name]
+        self.framework.observe(events.relation_created, self._on_relation_created_event)
+        self.framework.observe(events.relation_changed, self._on_relation_changed_event)
+        self.framework.observe(events.relation_broken, self._on_relation_broken_event)
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        try:
+            self._update_relation_data(self._client_config, event.relation.id)
+        except ClientConfigError as e:
+            self.on.invalid_client_config.emit(e.args[0])
+
+    def _on_relation_broken_event(self, event: RelationBrokenEvent) -> None:
+        # This may be caused by a provider unit being removed.
+        # Also the oauth data may still be there, perhaps we should remove this event altogether for now.
+
+        # Notify the requirer that the relation data was removed
+        self.on.oauth_info_removed.emit()
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        data = event.relation.data[event.app]
+        if not data:
+            logger.info("No relation data available.")
+            return
+
+        data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+
+        client_id = data.get("client_id")
+        client_secret_id = data.get("client_secret_id")
+        if not client_id or not client_secret_id:
+            logger.info("OAuth Provider info is available, waiting for client to be registered.")
+            # The client credentials are not ready yet, so we do nothing
+            # This could mean that the client credentials were removed from the databag,
+            # but we don't allow that (for now), so we don't have to check for it.
+            return
+
+        self.on.oauth_info_changed.emit(client_id, client_secret_id)
+
+    def _update_relation_data(
+        self, client_config: Optional[ClientConfig], relation_id: Optional[int] = None
+    ) -> None:
+        if not self.model.unit.is_leader() or not client_config:
+            return
+
+        if not isinstance(client_config, ClientConfig):
+            raise ValueError(f"Unexpected client_config type: {type(client_config)}")
+
+        client_config.validate()
+
+        try:
+            relation = self.model.get_relation(
+                relation_name=self._relation_name, relation_id=relation_id
+            )
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+
+        if not relation or not relation.app:
+            return
+
+        data = _dump_data(client_config.to_dict(), OAUTH_REQUIRER_JSON_SCHEMA)
+        relation.data[self.model.app].update(data)
+
+    def is_client_created(self, relation_id: Optional[int] = None) -> bool:
+        """Check if the client has been created."""
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+
+        if not relation or not relation.app:
+            return None
+
+        return (
+            "client_id" in relation.data[relation.app]
+            and "client_secret_id" in relation.data[relation.app]
+        )
+
+    def get_provider_info(
+        self, relation_id: Optional[int] = None
+    ) -> Optional[OauthProviderConfig]:
+        """Get the provider information from the databag."""
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+        if not relation or not relation.app:
+            return None
+
+        data = relation.data[relation.app]
+        if not data:
+            logger.info("No relation data available.")
+            return
+
+        data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+
+        client_secret_id = data.get("client_secret_id")
+        if client_secret_id:
+            _client_secret = self.get_client_secret(client_secret_id)
+            client_secret = _client_secret.get_content()[CLIENT_SECRET_FIELD]
+            data["client_secret"] = client_secret
+
+        oauth_provider = OauthProviderConfig.from_dict(data)
+        return oauth_provider
+
+    def get_client_secret(self, client_secret_id: str) -> Secret:
+        """Get the client_secret."""
+        client_secret = self.model.get_secret(id=client_secret_id)
+        return client_secret
+
+    def update_client_config(
+        self, client_config: ClientConfig, relation_id: Optional[int] = None
+    ) -> None:
+        """Update the client config stored in the object."""
+        self._client_config = client_config
+        self._update_relation_data(client_config, relation_id=relation_id)
+
+
+class ClientCreatedEvent(EventBase):
+    """Event to notify the Provider charm to create a new client."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        redirect_uri: str,
+        scope: str,
+        grant_types: List[str],
+        audience: List,
+        token_endpoint_auth_method: str,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.grant_types = grant_types
+        self.audience = audience
+        self.token_endpoint_auth_method = token_endpoint_auth_method
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "grant_types": self.grant_types,
+            "audience": self.audience,
+            "token_endpoint_auth_method": self.token_endpoint_auth_method,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.redirect_uri = snapshot["redirect_uri"]
+        self.scope = snapshot["scope"]
+        self.grant_types = snapshot["grant_types"]
+        self.audience = snapshot["audience"]
+        self.token_endpoint_auth_method = snapshot["token_endpoint_auth_method"]
+        self.relation_id = snapshot["relation_id"]
+
+    def to_client_config(self) -> ClientConfig:
+        """Convert the event information to a ClientConfig object."""
+        return ClientConfig(
+            self.redirect_uri,
+            self.scope,
+            self.grant_types,
+            self.audience,
+            self.token_endpoint_auth_method,
+        )
+
+
+class ClientChangedEvent(EventBase):
+    """Event to notify the Provider charm that the client config changed."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        redirect_uri: str,
+        scope: str,
+        grant_types: List,
+        audience: List,
+        token_endpoint_auth_method: str,
+        relation_id: int,
+        client_id: str,
+    ) -> None:
+        super().__init__(handle)
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.grant_types = grant_types
+        self.audience = audience
+        self.token_endpoint_auth_method = token_endpoint_auth_method
+        self.relation_id = relation_id
+        self.client_id = client_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "grant_types": self.grant_types,
+            "audience": self.audience,
+            "token_endpoint_auth_method": self.token_endpoint_auth_method,
+            "relation_id": self.relation_id,
+            "client_id": self.client_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.redirect_uri = snapshot["redirect_uri"]
+        self.scope = snapshot["scope"]
+        self.grant_types = snapshot["grant_types"]
+        self.audience = snapshot["audience"]
+        self.token_endpoint_auth_method = snapshot["token_endpoint_auth_method"]
+        self.relation_id = snapshot["relation_id"]
+        self.client_id = snapshot["client_id"]
+
+    def to_client_config(self) -> ClientConfig:
+        """Convert the event information to a ClientConfig object."""
+        return ClientConfig(
+            self.redirect_uri,
+            self.scope,
+            self.grant_types,
+            self.audience,
+            self.token_endpoint_auth_method,
+            self.client_id,
+        )
+
+
+class ClientDeletedEvent(EventBase):
+    """Event to notify the Provider charm that the client was deleted."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class OAuthProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `OAuthProviderEvents`."""
+
+    client_created = EventSource(ClientCreatedEvent)
+    client_changed = EventSource(ClientChangedEvent)
+    client_deleted = EventSource(ClientDeletedEvent)
+
+
+class OAuthProvider(OAuthRelation):
+    """A provider object for OIDC Providers."""
+
+    on = OAuthProviderEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(
+            events.relation_changed,
+            self._get_client_config_from_relation_data,
+        )
+        self.framework.observe(
+            events.relation_broken,
+            self._on_relation_broken,
+        )
+
+    def _get_client_config_from_relation_data(self, event: RelationChangedEvent) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        data = event.relation.data[event.app]
+        if not data:
+            logger.info("No requirer relation data available.")
+            return
+
+        client_data = _load_data(data, OAUTH_REQUIRER_JSON_SCHEMA)
+        redirect_uri = client_data.get("redirect_uri")
+        scope = client_data.get("scope")
+        grant_types = client_data.get("grant_types")
+        audience = client_data.get("audience")
+        token_endpoint_auth_method = client_data.get("token_endpoint_auth_method")
+
+        data = event.relation.data[self._charm.app]
+        if not data:
+            logger.info("No provider relation data available.")
+            return
+        provider_data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+        client_id = provider_data.get("client_id")
+
+        relation_id = event.relation.id
+
+        if client_id:
+            # Modify an existing client
+            self.on.client_changed.emit(
+                redirect_uri,
+                scope,
+                grant_types,
+                audience,
+                token_endpoint_auth_method,
+                relation_id,
+                client_id,
+            )
+        else:
+            # Create a new client
+            self.on.client_created.emit(
+                redirect_uri, scope, grant_types, audience, token_endpoint_auth_method, relation_id
+            )
+
+    def _get_secret_label(self, relation: Relation) -> str:
+        return f"client_secret_{relation.id}"
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        # There is no way to tell if this event was emitted because the relation was removed or if one of
+        # the applications was scaled down. Until this is fixed, we don't delete the client.
+        # Workaround for https://github.com/canonical/operator/issues/888
+        # self._pop_relation_data(event.relation.id)
+
+        # self._delete_juju_secret(event.relation)
+        self.on.client_deleted.emit(event.relation.id)
+
+    def _create_juju_secret(self, client_secret: str, relation: Relation) -> Secret:
+        """Create a juju secret and grant it to a relation."""
+        secret = {CLIENT_SECRET_FIELD: client_secret}
+        juju_secret = self.model.app.add_secret(secret, label=self._get_secret_label(relation))
+        juju_secret.grant(relation)
+        return juju_secret
+
+    def _delete_juju_secret(self, relation: Relation) -> None:
+        try:
+            secret = self.model.get_secret(label=self._get_secret_label(relation))
+        except SecretNotFoundError:
+            return
+        else:
+            secret.remove_all_revisions()
+
+    def remove_secret(self, relation: Relation) -> None:
+        return self._delete_juju_secret(relation)
+
+    def set_provider_info_in_relation_data(
+        self,
+        issuer_url: str,
+        authorization_endpoint: str,
+        token_endpoint: str,
+        introspection_endpoint: str,
+        userinfo_endpoint: str,
+        jwks_endpoint: str,
+        scope: str,
+        groups: Optional[str] = None,
+        ca_chain: Optional[str] = None,
+        jwt_access_token: Optional[bool] = False,
+    ) -> None:
+        """Put the provider information in the databag."""
+        if not self.model.unit.is_leader():
+            return
+
+        data = {
+            "issuer_url": issuer_url,
+            "authorization_endpoint": authorization_endpoint,
+            "token_endpoint": token_endpoint,
+            "introspection_endpoint": introspection_endpoint,
+            "userinfo_endpoint": userinfo_endpoint,
+            "jwks_endpoint": jwks_endpoint,
+            "scope": scope,
+            "jwt_access_token": jwt_access_token,
+        }
+        if groups:
+            data["groups"] = groups
+        if ca_chain:
+            data["ca_chain"] = ca_chain
+
+        for relation in self.model.relations[self._relation_name]:
+            relation.data[self.model.app].update(_dump_data(data))
+
+    def set_client_credentials_in_relation_data(
+        self, relation_id: int, client_id: str, client_secret: str
+    ) -> None:
+        """Put the client credentials in the databag."""
+        if not self.model.unit.is_leader():
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id)
+        if not relation or not relation.app:
+            return
+        # TODO: What if we are refreshing the client_secret? We need to add a
+        # new revision for that
+        secret = self._create_juju_secret(client_secret, relation)
+        data = {"client_id": client_id, "client_secret_id": secret.id}
+        relation.data[self.model.app].update(_dump_data(data))

--- a/opensearch_single_kernel/managers/cluster.py
+++ b/opensearch_single_kernel/managers/cluster.py
@@ -7,6 +7,7 @@
 import logging
 import time
 from datetime import datetime
+from typing import Any
 
 from shortuuid import ShortUUID
 from tenacity import (
@@ -359,6 +360,31 @@ class ClusterManager(BaseManager):
             "plugins/opensearch-security/tools/securityadmin.sh", " ".join(args)
         )
         self._put_security_index_initialised()
+
+    def apply_security_config(self, admin_secrets: dict[str, Any], file: str) -> None:
+        """Run the security_admin script for specified config file, avoiding changes to others."""
+        if not file.startswith("opensearch-security"):
+            raise ValueError("security config is expected")
+
+        args = [
+            f"-f {self.workload.paths.conf}/{file}",
+            f"-cn {self.state.application.deployment_desc.config.cluster_name}",
+            f"-h {self.state.host_ip}",
+            f"-ts {self.workload.paths.certs}/ca.p12",
+            f"-tspass {admin_secrets['truststore-password']}",
+            "-tst PKCS12",
+            f"-ks {self.workload.paths.certs}/{CertType.APP_ADMIN}.p12",
+            f"-kspass {admin_secrets['keystore-password']}",
+            "-kst PKCS12",
+        ]
+
+        admin_key_pwd = admin_secrets.get("key-password", None)
+        if admin_key_pwd is not None:
+            args.append(f"-keypass {admin_key_pwd}")
+
+        self.workload.run_script(
+            "plugins/opensearch-security/tools/securityadmin.sh", " ".join(args)
+        )
 
     def check_if_can_start(self) -> bool:
         """Apply the directives computed by the opensearch peer cluster manager."""

--- a/opensearch_single_kernel/managers/config.py
+++ b/opensearch_single_kernel/managers/config.py
@@ -43,8 +43,8 @@ class ConfigManager(BaseManager):
     ) -> bool:
         """Reconcile whole Opensearch config using values from application state.
 
-        Updates opensearch.yml & unicast_hosts.txt config files and assures
-        jvm.options & opensearch-security/config.yml are populated with right static options.
+        Updates opensearch.yml & unicast_hosts.txt & opensearch-security/config.yml config files
+        and assures jvm.options is populated with right static options.
 
         Args:
             roles: override node roles got from nodes_config.
@@ -52,7 +52,7 @@ class ConfigManager(BaseManager):
             cm_ips: override seed_hosts got from nodes_config.
 
         Returns:
-            whether the opensearch.yml config was changed.
+            whether the config was changed.
         """
         if roles is None:
             roles = self._opensearch_roles
@@ -69,7 +69,8 @@ class ConfigManager(BaseManager):
         )
 
         self._update_static_jvm_options()
-        self._update_static_security_options()
+
+        self.update_security_config()
 
         if cm_ips:
             self._update_seeds_file(cm_ips)
@@ -80,6 +81,31 @@ class ConfigManager(BaseManager):
 
         res = self.yaml_setter.rewrite(self.CONFIG_YML, config)
         return res
+
+    def update_security_config(self) -> bool:
+        """Reconcile whole Opensearch security config using values from application state.
+
+        Updates opensearch-security/config.yml config file.
+
+        Returns:
+            whether the config was changed.
+        """
+        config = {
+            "_meta": {
+                "type": "config",
+                "config_version": 2,
+            },
+            "config": {
+                "dynamic": {
+                    "authc": self._security_authc_static_config()
+                    | self._security_authc_jwt_config()
+                    | self._security_authc_oauth_config(),
+                    "authz": self._security_authz_static_config(),
+                },
+            },
+        }
+
+        return self.yaml_setter.rewrite(self.SECURITY_CONFIG_YML, config)
 
     @staticmethod
     def _opensearch_static_config() -> dict[str, Any]:
@@ -242,27 +268,207 @@ class ConfigManager(BaseManager):
             "-Djdk.tls.client.protocols=TLSv1.2",
         )
 
-    def _update_static_security_options(self) -> None:
-        """Update Opensearch security config file with the right static options.
+    @staticmethod
+    def _security_authc_static_config() -> dict[str, Any]:
+        """Get set of static config options for the Opensearch security.
 
-        Configures TLS and basic http for clients.
-        Intended for opensearch-security/config.yml file.
+        Intended for authc category in opensearch-security/config.yml config file.
         """
-        self.yaml_setter.put(
-            self.SECURITY_CONFIG_YML,
-            "config/dynamic/authc/basic_internal_auth_domain/http_enabled",
-            True,
+        return {
+            "basic_internal_auth_domain": {
+                "description": "Authenticate via HTTP Basic against internal users database",
+                "http_enabled": True,
+                "transport_enabled": True,
+                "order": 4,
+                "http_authenticator": {
+                    "type": "basic",
+                    "challenge": True,
+                },
+                "authentication_backend": {
+                    "type": "intern",
+                },
+            },
+            "clientcert_auth_domain": {
+                "description": "Authenticate via SSL client certificates",
+                "http_enabled": True,
+                "transport_enabled": True,
+                "order": 2,
+                "http_authenticator": {
+                    "type": "clientcert",
+                    "challenge": False,
+                    "config": {"username_attribute": "cn"},
+                },
+                "authentication_backend": {"type": "noop"},
+            },
+            "kerberos_auth_domain": {
+                "http_enabled": False,
+                "transport_enabled": False,
+                "order": 6,
+                "http_authenticator": {
+                    "type": "kerberos",
+                    "challenge": True,
+                    "config": {"krb_debug": False, "strip_realm_from_principal": True},
+                },
+                "authentication_backend": {"type": "noop"},
+            },
+            "proxy_auth_domain": {
+                "description": "Authenticate via proxy",
+                "http_enabled": False,
+                "transport_enabled": False,
+                "order": 3,
+                "http_authenticator": {
+                    "type": "proxy",
+                    "challenge": False,
+                    "config": {
+                        "user_header": "x-proxy-user",
+                        "roles_header": "x-proxy-roles",
+                    },
+                },
+                "authentication_backend": {"type": "noop"},
+            },
+            "ldap": {
+                "description": "Authenticate via LDAP or Active Directory",
+                "http_enabled": False,
+                "transport_enabled": False,
+                "order": 5,
+                "http_authenticator": {
+                    "type": "basic",
+                    "challenge": False,
+                },
+                "authentication_backend": {
+                    "type": "ldap",
+                    "config": {
+                        "enable_ssl": False,
+                        "enable_start_tls": False,
+                        "enable_ssl_client_auth": False,
+                        "verify_hostnames": True,
+                        "hosts": ["localhost:8389"],
+                        "bind_dn": None,
+                        "password": None,
+                        "userbase": "ou=people,dc=example,dc=com",
+                        "usersearch": "(sAMAccountName={0})",
+                        "username_attribute": None,
+                    },
+                },
+            },
+        }
+
+    def _security_authc_jwt_config(self) -> dict[str, Any]:
+        """Get set of JWT auth config options for the Opensearch security.
+
+        Intended for authc category in opensearch-security/config.yml config file.
+        """
+        jwt_config = self.state.server.jwt_auth_configuration
+        return {
+            "jwt_auth_domain": {
+                "description": "Authenticate via Json Web Token",
+                "http_enabled": bool(jwt_config),
+                "transport_enabled": bool(jwt_config),
+                "order": 0,
+                "http_authenticator": {
+                    "type": "jwt",
+                    "challenge": False,
+                    "config": (
+                        {
+                            "signing_key": jwt_config.signing_key,
+                            "jwt_header": jwt_config.jwt_header,
+                            "jwt_url_parameter": jwt_config.jwt_url_parameter,
+                            "roles_key": jwt_config.roles_key,
+                            "subject_key": jwt_config.subject_key,
+                            "required_audience": jwt_config.required_audience,
+                            "required_issuer": jwt_config.required_issuer,
+                            "jwt_clock_skew_tolerance_seconds": jwt_config.jwt_clock_skew_tolerance_seconds,
+                        }
+                        if jwt_config
+                        else {
+                            "signing_key": "base64 encoded HMAC key or public RSA/ECDSA pem key",
+                            "jwt_header": "Authorization",
+                            "jwt_url_parameter": None,
+                            "roles_key": None,
+                            "subject_key": None,
+                            "jwt_clock_skew_tolerance_seconds": 30,
+                        }
+                    ),
+                },
+                "authentication_backend": {"type": "noop"},
+            }
+        }
+
+    def _security_authc_oauth_config(self) -> dict[str, Any]:
+        """Get set of OAuth config options for the Opensearch security.
+
+        Intended for authc category in opensearch-security/config.yml config file.
+        """
+        return (
+            {
+                "openid_auth_domain": {
+                    "http_enabled": True,
+                    "transport_enabled": True,
+                    # NOTE: Order value needs to be lower than basic_internal_auth_domain section,
+                    # which is set to 4 by default. Only available number is 1, if we want a
+                    # different number, all other numbers need to be reshuffled.
+                    "order": 1,
+                    "http_authenticator": {
+                        "type": "openid",
+                        "challenge": False,
+                        "config": {
+                            "subject_key": "sub",
+                            "openid_connect_url": self.state.server.oauth_openid_connect_url,
+                            "openid_connect_idp": {
+                                "enable_ssl": True,
+                                "verify_hostnames": False,
+                                # NOTE: this assumes Hydra and Opensearch
+                                # are using the same certificates relation.
+                                "pemtrustedcas_filepath": self.workload.paths.certs_chain.as_posix(),
+                            },
+                        },
+                    },
+                    "authentication_backend": {"type": "noop"},
+                }
+            }
+            if self.state.server.oauth_openid_connect_url
+            else {}
         )
-        self.yaml_setter.put(
-            self.SECURITY_CONFIG_YML,
-            "config/dynamic/authc/clientcert_auth_domain/http_enabled",
-            True,
-        )
-        self.yaml_setter.put(
-            self.SECURITY_CONFIG_YML,
-            "config/dynamic/authc/clientcert_auth_domain/transport_enabled",
-            True,
-        )
+
+    @staticmethod
+    def _security_authz_static_config() -> dict[str, Any]:
+        """Get set of static config options for the Opensearch security.
+
+        Intended for authz category in opensearch-security/config.yml config file.
+        """
+        return {
+            "roles_from_myldap": {
+                "description": "Authorize via LDAP or Active Directory",
+                "http_enabled": False,
+                "transport_enabled": False,
+                "authorization_backend": {
+                    "type": "ldap",
+                    "config": {
+                        "enable_ssl": False,
+                        "enable_start_tls": False,
+                        "enable_ssl_client_auth": False,
+                        "verify_hostnames": True,
+                        "hosts": ["localhost:8389"],
+                        "bind_dn": None,
+                        "password": None,
+                        "rolebase": "ou=groups,dc=example,dc=com",
+                        "rolesearch": "(member={0})",
+                        "userroleattribute": None,
+                        "userrolename": "disabled",
+                        "rolename": "cn",
+                        "resolve_nested_roles": True,
+                        "userbase": "ou=people,dc=example,dc=com",
+                        "usersearch": "(uid={0})",
+                    },
+                },
+            },
+            "roles_from_another_ldap": {
+                "description": "Authorize via another Active Directory",
+                "http_enabled": False,
+                "transport_enabled": False,
+                "authorization_backend": {"type": "ldap"},
+            },
+        }
 
     def update_seeds_config(self) -> None:
         """Reconcile Opensearch unicast_hosts.txt config file using values from nodes_config."""

--- a/opensearch_single_kernel/managers/tls.py
+++ b/opensearch_single_kernel/managers/tls.py
@@ -320,7 +320,7 @@ class TlsManager(BaseManager):
             ca_chain = admin_secret.get("chain")
 
         # we store the pem format to make it easier for the python requests lib
-        chain_path = self.workload.paths.certs / "chain.pem"
+        chain_path = self.workload.paths.certs_chain
         if parent_dir_path := chain_path.parent:
             self.workload.mkdir(parent_dir_path, parents=True, exist_ok=True)
 
@@ -331,7 +331,7 @@ class TlsManager(BaseManager):
 
     def _remove_ca_from_request_bundle(self, ca_cert: str) -> None:
         """Remove the CA cert from the request bundle for the requests module."""
-        bundle_path = self.workload.paths.certs / "chain.pem"
+        bundle_path = self.workload.paths.certs_chain
         if not bundle_path.exists():
             return
 

--- a/opensearch_single_kernel/workload/base.py
+++ b/opensearch_single_kernel/workload/base.py
@@ -124,8 +124,13 @@ class Paths:
         return "certificates"
 
     @property
+    def certs_chain(self) -> PathProtocol:
+        """Returns path to the certificates chain file."""
+        return self.certs / "chain.pem"
+
+    @property
     def seed_hosts(self) -> PathProtocol:
-        """Returns Seed hosts"""
+        """Returns path to the Opensearch seed hosts config file."""
         return self.conf / "unicast_hosts.txt"
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -61,6 +61,26 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+description = "High-level concurrency and networking framework on top of asyncio or Trio"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"},
+    {file = "anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703"},
+]
+
+[package.dependencies]
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
+idna = ">=2.8"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 description = "Annotate AST trees with source code positions"
@@ -1113,6 +1133,161 @@ testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "cry
 urllib3 = ["packaging", "urllib3"]
 
 [[package]]
+name = "greenlet"
+version = "3.3.2"
+description = "Lightweight in-process concurrent programming"
+optional = false
+python-versions = ">=3.10"
+groups = ["integration"]
+files = [
+    {file = "greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d"},
+    {file = "greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13"},
+    {file = "greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e"},
+    {file = "greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7"},
+    {file = "greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f"},
+    {file = "greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef"},
+    {file = "greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca"},
+    {file = "greenlet-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:5d0e35379f93a6d0222de929a25ab47b5eb35b5ef4721c2b9cbcc4036129ff1f"},
+    {file = "greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86"},
+    {file = "greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f"},
+    {file = "greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55"},
+    {file = "greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2"},
+    {file = "greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358"},
+    {file = "greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99"},
+    {file = "greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be"},
+    {file = "greenlet-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e692b2dae4cc7077cbb11b47d258533b48c8fde69a33d0d8a82e2fe8d8531d5"},
+    {file = "greenlet-3.3.2-cp311-cp311-win_arm64.whl", hash = "sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd"},
+    {file = "greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd"},
+    {file = "greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd"},
+    {file = "greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac"},
+    {file = "greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb"},
+    {file = "greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070"},
+    {file = "greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79"},
+    {file = "greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395"},
+    {file = "greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f"},
+    {file = "greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643"},
+    {file = "greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4"},
+    {file = "greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986"},
+    {file = "greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92"},
+    {file = "greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd"},
+    {file = "greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab"},
+    {file = "greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a"},
+    {file = "greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b"},
+    {file = "greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124"},
+    {file = "greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327"},
+    {file = "greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab"},
+    {file = "greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082"},
+    {file = "greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9"},
+    {file = "greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9"},
+    {file = "greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506"},
+    {file = "greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce"},
+    {file = "greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5"},
+    {file = "greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492"},
+    {file = "greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71"},
+    {file = "greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54"},
+    {file = "greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4"},
+    {file = "greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff"},
+    {file = "greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf"},
+    {file = "greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4"},
+    {file = "greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727"},
+    {file = "greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e"},
+    {file = "greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a"},
+    {file = "greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2"},
+]
+
+[package.extras]
+docs = ["Sphinx", "furo"]
+test = ["objgraph", "psutil", "setuptools"]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+description = "Pure-Python HTTP/2 protocol implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[package.dependencies]
+hpack = ">=4.1,<5"
+hyperframe = ">=6.1,<7"
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+description = "Pure-Python HPACK header encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
 name = "hvac"
 version = "2.4.0"
 description = "HashiCorp Vault API client"
@@ -1129,6 +1304,18 @@ requests = ">=2.27.1,<3.0.0"
 
 [package.extras]
 parser = ["pyhcl (>=0.4.4,<0.5.0)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+description = "Pure-Python HTTP/2 framing"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
+]
 
 [[package]]
 name = "identify"
@@ -1356,7 +1543,7 @@ files = [
 
 [package.dependencies]
 attrs = ">=22.2.0"
-jsonschema-specifications = ">=2023.03.6"
+jsonschema-specifications = ">=2023.3.6"
 referencing = ">=0.28.4"
 rpds-py = ">=0.7.1"
 
@@ -1423,7 +1610,7 @@ files = [
 ]
 
 [package.dependencies]
-certifi = ">=14.05.14"
+certifi = ">=14.5.14"
 google-auth = ">=1.0.1"
 oauthlib = ">=3.2.2"
 python-dateutil = ">=2.5.3"
@@ -1436,6 +1623,38 @@ websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.dev0 || >=0.43.dev0"
 
 [package.extras]
 adal = ["adal (>=1.0.2)"]
+
+[[package]]
+name = "lightkube"
+version = "0.19.1"
+description = "Lightweight kubernetes client library"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "lightkube-0.19.1-py3-none-any.whl", hash = "sha256:49fef08a1c7aa42082820111ffd5dbbaf78f54c99385810690fc9d94eef5c80d"},
+    {file = "lightkube-0.19.1.tar.gz", hash = "sha256:4c8526068024c194c02fbc0ca6021922feb4b1b9d741d330129f873b27e0fe97"},
+]
+
+[package.dependencies]
+httpx = {version = ">=0.28.1,<1.0.0", extras = ["http2"]}
+lightkube-models = ">=1.15.12.0"
+pyyaml = "*"
+
+[package.extras]
+jinja-templates = ["jinja2"]
+
+[[package]]
+name = "lightkube-models"
+version = "1.35.0.8"
+description = "Models and Resources for lightkube module"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "lightkube_models-1.35.0.8-py3-none-any.whl", hash = "sha256:d01fce42f96baf47a77a571bff59d6a513e96ae043fc03cfaaaaf79c609c4441"},
+    {file = "lightkube_models-1.35.0.8.tar.gz", hash = "sha256:dbc624596a7d94e6c43c5deda972be964202e0e8f26e2ab8e61d589d710b5e22"},
+]
 
 [[package]]
 name = "macaroonbakery"
@@ -1685,6 +1904,29 @@ files = [
 ]
 
 [[package]]
+name = "oauth_tools"
+version = "0.1.2"
+description = "A collection of tools useful for testing oauth interface"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = []
+develop = false
+
+[package.dependencies]
+httpx = "0.28.1"
+lightkube = "*"
+pytest = "*"
+pytest_operator = "*"
+pytest-playwright = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/canonical/iam-bundle"
+reference = "921d113325eed156e5b54f97c42e6c50810180c0"
+resolved_reference = "921d113325eed156e5b54f97c42e6c50810180c0"
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1714,7 +1956,7 @@ files = [
 ]
 
 [package.dependencies]
-certifi = ">=2024.07.04"
+certifi = ">=2024.7.4"
 Events = "*"
 python-dateutil = "*"
 requests = ">=2.32.0,<3.0.0"
@@ -1916,6 +2158,28 @@ files = [
 docs = ["furo (>=2025.9.25)", "proselint (>=0.14)", "sphinx (>=8.2.3)", "sphinx-autodoc-typehints (>=3.2)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.4.2)", "pytest-cov (>=7)", "pytest-mock (>=3.15.1)"]
 type = ["mypy (>=1.18.2)"]
+
+[[package]]
+name = "playwright"
+version = "1.58.0"
+description = "A high-level API to automate web browsers"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606"},
+    {file = "playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71"},
+    {file = "playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117"},
+    {file = "playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b"},
+    {file = "playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa"},
+    {file = "playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99"},
+    {file = "playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8"},
+    {file = "playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b"},
+]
+
+[package.dependencies]
+greenlet = ">=3.1.1,<4.0.0"
+pyee = ">=13,<14"
 
 [[package]]
 name = "pluggy"
@@ -2254,6 +2518,24 @@ snowballstemmer = ">=2.2.0"
 toml = ["tomli (>=1.2.3) ; python_version < \"3.11\""]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228"},
+    {file = "pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "mypy", "pytest", "pytest-asyncio ; python_version >= \"3.4\"", "pytest-trio ; python_version >= \"3.7\"", "sphinx", "toml", "tox", "trio", "trio ; python_version > \"3.6\"", "trio-typing ; python_version > \"3.6\"", "twine", "twisted", "validate-pyproject[all]"]
+
+[[package]]
 name = "pyflakes"
 version = "3.2.0"
 description = "passive checker of Python programs"
@@ -2436,6 +2718,25 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+description = "pytest plugin for URL based testing"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6"},
+    {file = "pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+requests = ">=2.9"
+
+[package.extras]
+test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "pytest-localserver (>=0.7.1)", "tox (>=3.24.5)"]
+
+[[package]]
 name = "pytest-microceph"
 version = "0.1.0"
 description = ""
@@ -2495,6 +2796,24 @@ pytest-asyncio = "<0.23"
 pyyaml = "*"
 
 [[package]]
+name = "pytest-playwright"
+version = "0.7.2"
+description = "A pytest wrapper with fixtures for Playwright to automate web browsers"
+optional = false
+python-versions = ">=3.10"
+groups = ["integration"]
+files = [
+    {file = "pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38"},
+    {file = "pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770"},
+]
+
+[package.dependencies]
+playwright = ">=1.18"
+pytest = ">=6.2.4,<10.0.0"
+pytest-base-url = ">=1.0.0,<3.0.0"
+python-slugify = ">=6.0.0,<9.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2508,6 +2827,24 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+description = "A Python slugify application that also handles Unicode"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
+    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
+]
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "pytokens"
@@ -2960,10 +3297,10 @@ files = [
 ]
 
 [package.dependencies]
-botocore = ">=1.37.4,<2.0a.0"
+botocore = ">=1.37.4,<2.0a0"
 
 [package.extras]
-crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
 name = "setuptools"
@@ -3072,6 +3409,18 @@ files = [
 [package.extras]
 doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+optional = false
+python-versions = "*"
+groups = ["integration"]
+files = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
 
 [[package]]
 name = "tomli"
@@ -3369,4 +3718,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "ca422b5975dc186e3fd9bdf4c77000b0f24abfe3eb3e436fafc00c64de6c9853"
+content-hash = "5b79308e349db6ee0b141247c5740746acaf246fed53251968433d5518a8e5dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ allure-pytest-default-results = "^0.1.3"
 # Azure integration tests
 azure-identity = "^1.23.0"
 azure-storage-blob = "^12.25.1"
+oauth_tools = {git = "https://github.com/canonical/iam-bundle", rev = "921d113325eed156e5b54f97c42e6c50810180c0"}
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"

--- a/spread.yaml
+++ b/spread.yaml
@@ -172,6 +172,8 @@ prepare: |
     concierge prepare --trace -c concierge-lxd.yaml --extra-debs pipx
     if [[ $SPREAD_TASK == *"oauth"* ]]
     then
+      mkdir -p ~/.kube
+      microk8s.kubectl config view --raw > ~/.kube/config
       /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
       # microk8s config | juju add-k8s uk8s --client
       # juju add-model --controller concierge-lxd testing-uk8s

--- a/spread.yaml
+++ b/spread.yaml
@@ -174,7 +174,10 @@ prepare: |
     then
       mkdir -p ~/.kube
       microk8s.kubectl config view --raw > ~/.kube/config
-      /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
+      export LOCAL_IP="127.0.0.1"
+      export PUBLIC_IP=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+      sed -i 's/'${LOCAL_IP}'/'${PUBLIC_IP}'/g' ~/.kube/config
+      cat ~/.kube/config | juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
       # microk8s config | juju add-k8s uk8s --client
       # juju add-model --controller concierge-lxd testing-uk8s
     fi

--- a/spread.yaml
+++ b/spread.yaml
@@ -135,7 +135,7 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_SUITE == *"oauth"*]]
+  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_SUITE == *"oauth"* ]]
   then
     # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
     # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75

--- a/spread.yaml
+++ b/spread.yaml
@@ -159,6 +159,14 @@ prepare: |
     microk8s start
   fi
 
+  if [[ $SPREAD_SUITE == *"k8s"* ]]
+  then
+    concierge prepare --trace -c concierge-microk8s.yaml
+    # microk8s config | juju add-k8s my-k8s --client
+    # juju bootstrap my-k8s concierge-microk8s
+    # juju add-model --controller concierge-microk8s testing
+  fi
+
   if [[ $SPREAD_SUITE == *"vm"* ]]
   then
     concierge prepare --trace -c concierge-lxd.yaml --extra-debs pipx
@@ -168,14 +176,6 @@ prepare: |
       # microk8s config | juju add-k8s uk8s --client
       # juju add-model --controller concierge-lxd testing-uk8s
     fi
-  fi
-
-  if [[ $SPREAD_SUITE == *"k8s"* ]]
-  then
-    concierge prepare --trace -c concierge-microk8s.yaml
-    # microk8s config | juju add-k8s my-k8s --client
-    # juju bootstrap my-k8s concierge-microk8s
-    # juju add-model --controller concierge-microk8s testing
   fi
 
   # Install charmcraft & pipx (on lxd-vm backend)

--- a/spread.yaml
+++ b/spread.yaml
@@ -135,7 +135,7 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_SUITE == *"oauth"* ]]
+  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
   then
     # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
     # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
@@ -162,7 +162,7 @@ prepare: |
   if [[ $SPREAD_SUITE == *"vm"* ]]
   then
     concierge prepare --trace -c concierge-lxd.yaml --extra-debs pipx
-    if [[ $SPREAD_SUITE == *"oauth"* ]]
+    if [[ $SPREAD_TASK == *"oauth"* ]]
     then
       /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
       # microk8s config | juju add-k8s uk8s --client

--- a/spread.yaml
+++ b/spread.yaml
@@ -135,7 +135,7 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* ]]
+  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_SUITE == *"oauth"*]]
   then
     # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
     # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
@@ -162,6 +162,12 @@ prepare: |
   if [[ $SPREAD_SUITE == *"vm"* ]]
   then
     concierge prepare --trace -c concierge-lxd.yaml --extra-debs pipx
+    if [[ $SPREAD_SUITE == *"oauth"* ]]
+    then
+      /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
+      # microk8s config | juju add-k8s uk8s --client
+      # juju add-model --controller concierge-lxd testing-uk8s
+    fi
   fi
 
   if [[ $SPREAD_SUITE == *"k8s"* ]]

--- a/spread.yaml
+++ b/spread.yaml
@@ -159,7 +159,7 @@ prepare: |
     microk8s start
   fi
 
-  if [[ $SPREAD_SUITE == *"k8s"* ]]
+  if [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
   then
     concierge prepare --trace -c concierge-microk8s.yaml
     # microk8s config | juju add-k8s my-k8s --client

--- a/tests/integration/bundle-iam.yaml
+++ b/tests/integration/bundle-iam.yaml
@@ -1,0 +1,92 @@
+---
+bundle: kubernetes
+name: identity-platform
+description: |
+  The Canonical Identity Platform is a composable identity broker and identity provider based on open source products.
+docs: https://discourse.charmhub.io/t/canonical-identity-platform/11825
+website: https://github.com/canonical/iam-bundle
+issues: https://github.com/canonical/iam-bundle/issues
+applications:
+  hydra:
+    charm: hydra
+    revision: 339
+    resources:
+      oci-image: ghcr.io/canonical/hydra:2.3.0-canonical
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  kratos:
+    charm: kratos
+    revision: 500
+    resources:
+      oci-image: ghcr.io/canonical/kratos:1.3.1
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  kratos-external-idp-integrator:
+    charm: kratos-external-idp-integrator
+    channel: latest/edge
+    revision: 245
+    scale: 1
+    series: jammy
+  identity-platform-login-ui-operator:
+    charm: identity-platform-login-ui-operator
+    revision: 146
+    resources:
+      oci-image: ghcr.io/canonical/identity-platform-login-ui:v0.21.2
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  postgresql-k8s:
+    charm: postgresql-k8s
+    channel: 14/stable
+    resources:
+      postgresql-image: ghcr.io/canonical/charmed-postgresql@sha256:e2283194f7f8d9997fb06f0fd1ab0ec3938ce73ac001133bd8fd393ebe83acc7
+    series: jammy
+    scale: 1
+    trust: true
+    options:
+      plugin_pg_trgm_enable: true
+      plugin_btree_gin_enable: true
+  self-signed-certificates:
+    charm: self-signed-certificates
+    revision: 155
+    channel: latest/stable
+    scale: 1
+  traefik-admin:
+    charm: traefik-k8s
+    channel: latest/stable
+    revision: 176
+    resources:
+      traefik-image: docker.io/ubuntu/traefik:2-22.04
+    series: focal
+    scale: 1
+    trust: true
+  traefik-public:
+    charm: traefik-k8s
+    channel: latest/stable
+    revision: 176
+    resources:
+      traefik-image: docker.io/ubuntu/traefik:2-22.04
+    series: focal
+    scale: 1
+    trust: true
+relations:
+  - [hydra:pg-database, postgresql-k8s:database]
+  - [kratos:pg-database, postgresql-k8s:database]
+  - [kratos:hydra-endpoint-info, hydra:hydra-endpoint-info]
+  - [kratos-external-idp-integrator:kratos-external-idp, kratos:kratos-external-idp]
+  - [hydra:admin-ingress, traefik-admin:ingress]
+  - [hydra:public-ingress, traefik-public:ingress]
+  - [kratos:admin-ingress, traefik-admin:ingress]
+  - [kratos:public-ingress, traefik-public:ingress]
+  - [identity-platform-login-ui-operator:ingress, traefik-public:ingress]
+  - [identity-platform-login-ui-operator:hydra-endpoint-info, hydra:hydra-endpoint-info]
+  - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
+  - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
+  - [identity-platform-login-ui-operator:kratos-info, kratos:kratos-info]
+  - [traefik-admin:certificates, self-signed-certificates:certificates]
+  - [traefik-public:certificates, self-signed-certificates:certificates]

--- a/tests/integration/bundle-iam.yaml
+++ b/tests/integration/bundle-iam.yaml
@@ -90,3 +90,4 @@ relations:
   - [identity-platform-login-ui-operator:kratos-info, kratos:kratos-info]
   - [traefik-admin:certificates, self-signed-certificates:certificates]
   - [traefik-public:certificates, self-signed-certificates:certificates]
+

--- a/tests/integration/bundle-iam.yaml
+++ b/tests/integration/bundle-iam.yaml
@@ -90,4 +90,3 @@ relations:
   - [identity-platform-login-ui-operator:kratos-info, kratos:kratos-info]
   - [traefik-admin:certificates, self-signed-certificates:certificates]
   - [traefik-public:certificates, self-signed-certificates:certificates]
-

--- a/tests/integration/relations/conftest.py
+++ b/tests/integration/relations/conftest.py
@@ -27,9 +27,9 @@ async def ops_test_microk8s(
     Returns:
         OpsTest object with MicroK8s connection and Juju model.
     """
-    model_name = f"{ops_test.model_name}-uk8s"
+    model_name = f"{ops_test.model_name}-{MICROK8S_CLOUD_NAME}"
     request.config.option.controller = ops_test.controller_name
-    request.config.option.cloud = "uk8s"
+    request.config.option.cloud = MICROK8S_CLOUD_NAME
     request.config.option.model = model_name
     request.config.option.model_alias = model_name
     ops_res = OpsTest(request, tmp_path_factory)
@@ -58,7 +58,7 @@ async def microk8s_model(ops_test: OpsTest) -> AsyncGenerator[Model, Any]:
     Returns:
         Connected Juju model.
     """
-    model_name = f"{ops_test.model_name}-uk8s"
+    model_name = f"{ops_test.model_name}-{MICROK8S_CLOUD_NAME}"
     controller = Controller()
     await controller.connect()
     if model_name in await controller.list_models():

--- a/tests/integration/relations/test_jwt.py
+++ b/tests/integration/relations/test_jwt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import asyncio

--- a/tests/integration/relations/test_jwt.py
+++ b/tests/integration/relations/test_jwt.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import base64
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+import requests
+from pytest_operator.plugin import OpsTest
+
+from opensearch_single_kernel.common.constants import (
+    JWT_CONFIG_RELATION,
+)
+from opensearch_single_kernel.common.statuses import CharmStatuses
+from tests.integration.conftest import (
+    APP_NAME,
+    CONFIG_OPTS,
+    MODEL_CONFIG,
+)
+from tests.integration.helpers import (
+    get_leader_unit_ip,
+    http_request,
+    wait_until,
+)
+from tests.integration.tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
+
+logger = logging.getLogger(__name__)
+
+
+ENCODING_ALGORITHM = "HS256"
+DEFAULT_NUM_UNITS = 3
+JWT_APP_NAME = "jwt-integrator"
+REL_ORCHESTRATOR = "peer-cluster-orchestrator"
+REL_PEER = "peer-cluster"
+MAIN_APP = "opensearch-main"
+FAILOVER_APP = "opensearch-failover"
+DATA_APP = "opensearch-data"
+CLUSTER_NAME = "log-app"
+APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 3}
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_small_cluster(charm, series, ops_test: OpsTest) -> None:
+    """Deploy OpenSearch and JWT integrator, configure and integrate them."""
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    await ops_test.model.deploy(
+        charm,
+        num_units=DEFAULT_NUM_UNITS,
+        series=series,
+        config=CONFIG_OPTS,
+    )
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await ops_test.model.deploy(
+        TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
+    )
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units=DEFAULT_NUM_UNITS,
+    )
+
+    await ops_test.model.deploy("jwt-integrator", channel="1/edge")
+    await wait_until(ops_test, apps=[JWT_APP_NAME], apps_statuses=["blocked"])
+
+
+@pytest.mark.abort_on_fail
+async def test_configure_and_use_jwt(charm, series, ops_test: OpsTest) -> None:
+    """Configure JWT authentication and access the cluster with the token."""
+    global generated_jwt
+    generated_jwt = generate_json_web_token()
+
+    logger.info("Creating signing-key secret")
+    secret_name = "jwt-signing-key"
+    secret_id = (
+        await ops_test.juju(
+            "add-secret", secret_name, f"signing-key={generated_jwt['signing-key']}"
+        )
+    )[1].strip()
+    await ops_test.model.grant_secret(secret_name=secret_name, application=JWT_APP_NAME)
+
+    logger.info(f"Configuring {JWT_APP_NAME}")
+    jwt_config = {
+        "signing-key": secret_id,
+        "roles-key": "role",
+        "subject-key": "user",
+    }
+    await ops_test.model.applications[JWT_APP_NAME].set_config(jwt_config)
+
+    logger.info(f"Integrating {APP_NAME} with {JWT_APP_NAME}")
+    await ops_test.model.integrate(JWT_APP_NAME, APP_NAME)
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME, JWT_APP_NAME],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={APP_NAME: DEFAULT_NUM_UNITS, JWT_APP_NAME: 1},
+    )
+
+    logger.info("Test access to `/_cat/nodes` with JWT")
+    ip_address = await get_leader_unit_ip(ops_test, app=APP_NAME)
+    url = f"https://{ip_address}:9200/_cat/nodes"
+    jwt_result = requests.get(
+        url, headers={"Authorization": f"Bearer {generated_jwt['token']}"}, verify=False
+    )
+    assert jwt_result.status_code == 200, "Request failed"
+    logger.info("Access with JWT successful")
+
+    basic_auth_result = await http_request(ops_test, "GET", url, resp_status_code=True)
+    assert basic_auth_result == 200, "Request failed"
+    logger.info("Access with Basic Auth successful")
+
+    logger.info(f"Remove relation with {JWT_APP_NAME}")
+    remove_relation_cmd = (
+        f"remove-relation {JWT_APP_NAME}:{JWT_CONFIG_RELATION} {APP_NAME}:{JWT_CONFIG_RELATION}"
+    )
+    await ops_test.juju(*remove_relation_cmd.split(), check=True)
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units=DEFAULT_NUM_UNITS,
+    )
+
+    logger.info("Test access to `/_cat/nodes` with JWT")
+    result = requests.get(
+        url, headers={"Authorization": f"Bearer {generated_jwt['token']}"}, verify=False
+    )
+    assert result.status_code == 401, "`Unauthorized` error expected"
+    logger.info("Access with JWT failed as expected")
+
+    basic_auth_result = await http_request(ops_test, "GET", url, resp_status_code=True)
+    assert basic_auth_result == 200, "Request failed"
+    logger.info("Access with Basic Auth successful")
+
+    # remove Opensearch to allow for follow-up test
+    logger.info("Remove Opensearch cluster")
+    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9182")
+async def test_configure_and_use_jwt_large_cluster(charm, series, ops_test: OpsTest) -> None:
+    """Create a large deployment of OpenSearch."""
+    logger.info("Create large deployment cluster of Opensearch")
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            application_name=MAIN_APP,
+            num_units=APP_UNITS[MAIN_APP],
+            series=series,
+            config={"cluster_name": CLUSTER_NAME, "roles": "cluster_manager"} | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=FAILOVER_APP,
+            num_units=APP_UNITS[FAILOVER_APP],
+            series=series,
+            config={
+                "cluster_name": CLUSTER_NAME,
+                "init_hold": True,
+                "roles": "cluster_manager",
+            }
+            | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=DATA_APP,
+            num_units=APP_UNITS[DATA_APP],
+            series=series,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "data"}
+            | CONFIG_OPTS,
+        ),
+    )
+
+    # integrate TLS to all applications
+    for app in [MAIN_APP, FAILOVER_APP, DATA_APP]:
+        await ops_test.model.integrate(app, TLS_CERTIFICATES_APP_NAME)
+
+    # integrate large deployment cluster
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}")
+
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {"active": []},
+            FAILOVER_APP: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+    )
+
+    logger.info(f"Integrating {DATA_APP} with {JWT_APP_NAME} - this will result in blocked status")
+    await ops_test.model.integrate(
+        f"{JWT_APP_NAME}:{JWT_CONFIG_RELATION}",
+        f"{DATA_APP}:{JWT_CONFIG_RELATION}",
+    )
+    await wait_until(
+        ops_test,
+        apps=[DATA_APP],
+        apps_full_statuses={
+            DATA_APP: {"blocked": [CharmStatuses.JWT_RELATION_INVALID.value.message]},
+        },
+        wait_for_exact_units={DATA_APP: 3},
+    )
+
+    logger.info("Test access to `/_cat/nodes` with JWT")
+    ip_address = await get_leader_unit_ip(ops_test, app=DATA_APP)
+    url = f"https://{ip_address}:9200/_cat/nodes"
+    result = requests.get(
+        url, headers={"Authorization": f"Bearer {generated_jwt['token']}"}, verify=False
+    )
+    assert result.status_code == 401, "`Unauthorized` error expected"
+    logger.info("Access with JWT failed as expected")
+
+    logger.info(f"Remove relation with {DATA_APP}")
+    remove_relation_cmd = (
+        f"remove-relation {JWT_APP_NAME}:{JWT_CONFIG_RELATION} {DATA_APP}:{JWT_CONFIG_RELATION}"
+    )
+    await ops_test.juju(*remove_relation_cmd.split(), check=True)
+
+    await wait_until(
+        ops_test,
+        apps=[DATA_APP],
+        apps_full_statuses={DATA_APP: {"active": []}},
+        units_statuses=["active"],
+        wait_for_exact_units={DATA_APP: 3},
+    )
+
+    logger.info(f"Integrating {MAIN_APP} with {JWT_APP_NAME}")
+    await ops_test.model.integrate(
+        f"{JWT_APP_NAME}:{JWT_CONFIG_RELATION}",
+        f"{MAIN_APP}:{JWT_CONFIG_RELATION}",
+    )
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {"active": []},
+            FAILOVER_APP: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+    )
+
+    logger.info("Test access to `/_cat/nodes` with JWT")
+    ip_address = await get_leader_unit_ip(ops_test, app=MAIN_APP)
+    url = f"https://{ip_address}:9200/_cat/nodes"
+    result = requests.get(
+        url, headers={"Authorization": f"Bearer {generated_jwt['token']}"}, verify=False
+    )
+    assert result.status_code == 200, "Request failed"
+    logger.info("Access with JWT successful")
+
+
+def encode_str_as_base64(input_str) -> str:
+    string_as_bytes = input_str.encode("ascii")
+    string_as_base64 = base64.urlsafe_b64encode(string_as_bytes).decode("utf-8")
+    return string_as_base64
+
+
+def generate_json_web_token() -> dict[str, str]:
+    """Generate a JWT specific for testing in Opensearch.
+
+    Returns: a dictionary containing the token and the signing key.
+    """
+    # Secret key for signing the JWT
+    signing_key = secrets.token_urlsafe(32)
+
+    # Payload data
+    payload = {
+        "role": "admin",
+        "user": "admin",
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=60),
+    }
+
+    # Encode the token and the signing-key
+    encoded_jwt = jwt.encode(payload, signing_key, algorithm=ENCODING_ALGORITHM)
+    signing_key_encoded = encode_str_as_base64(signing_key)
+
+    # Test if valid JWT
+    try:
+        jwt.decode(encoded_jwt, signing_key, algorithms=[ENCODING_ALGORITHM])
+        logging.info("JWT successfully generated")
+        return {"token": encoded_jwt, "signing-key": signing_key_encoded}
+    except jwt.InvalidTokenError:
+        raise

--- a/tests/integration/relations/test_oauth.py
+++ b/tests/integration/relations/test_oauth.py
@@ -1,0 +1,414 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import json
+import logging
+from asyncio import gather
+
+import pytest
+import requests
+from juju.client.client import Action
+from juju.model import Model
+from oauth_tools import (
+    ExternalIdpService,
+    deploy_identity_bundle,
+)
+from pytest_operator.plugin import OpsTest
+
+from opensearch_single_kernel.common.statuses import CharmStatuses
+from tests.integration.conftest import CONFIG_OPTS
+from tests.integration.helpers import get_leader_unit_ip, wait_until
+
+pytest_plugins = ["oauth_tools.fixtures"]
+
+IDENTITY_PLATFORM_NAME = "identity-platform"
+DATA_INTEGRATOR_NAME = "data-integrator"
+SECOND_DATA_INTEGRATOR_NAME = "second-data-integrator"
+
+DATA_INTEGRATOR_CONFIG = {
+    "index-name": "admin-index",
+    "extra-user-roles": "admin",
+}
+SECOND_DATA_INTEGRATOR_CONFIG = {
+    "index-name": "dev-index",
+}
+MAIN_APP = "opensearch-main"
+FAILOVER_APP = "opensearch-failover"
+DATA_APP = "opensearch-data"
+CLUSTER_NAME = "log-app"
+REL_ORCHESTRATOR = "peer-cluster-orchestrator"
+REL_PEER = "peer-cluster"
+APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 3}
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_deploy(ops_test: OpsTest, charm, series, microk8s_model: Model):
+    """Deploy OpenSearch, data integrator and identity platform (K8s) simultaneously."""
+    await gather(
+        ops_test.model.deploy(
+            charm,
+            num_units=2,
+            series=series,
+            config=CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            DATA_INTEGRATOR_NAME,
+            config=DATA_INTEGRATOR_CONFIG,
+        ),
+    )
+    await gather(
+        ops_test.model.wait_for_idle(timeout=1000), microk8s_model.wait_for_idle(timeout=1000)
+    )
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_deploy_identity_bundle(
+    ops_test: OpsTest, ops_test_microk8s: OpsTest, ext_idp_service: ExternalIdpService
+):
+    """Deploy identity platform on K8s and wait for both models to complete deployments."""
+    await deploy_identity_bundle(
+        ops_test=ops_test_microk8s,
+        bundle_url="./tests/integration/bundle-iam.yaml",
+        ext_idp_service=ext_idp_service,
+    )
+    await gather(
+        ops_test.model.wait_for_idle(),
+        ops_test_microk8s.model.wait_for_idle(raise_on_error=False),
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_setup_relations(ops_test: OpsTest, microk8s_model: Model):
+    """Establish all the required relations.
+
+    Connects OpenSearch, data integrator and identity platform (cross-model).
+    """
+    await microk8s_model.create_offer("certificates", "certificates", "self-signed-certificates")
+    await ops_test.model.consume(f"admin/{microk8s_model.name}.certificates")
+    await ops_test.model.integrate("opensearch:certificates", "certificates")
+
+    await microk8s_model.create_offer("oauth", "oauth", "hydra")
+    await ops_test.model.consume(f"admin/{microk8s_model.name}.oauth")
+    await ops_test.model.integrate("opensearch:oauth", "oauth")
+
+    await ops_test.model.integrate(
+        "opensearch:opensearch-client", f"{DATA_INTEGRATOR_NAME}:opensearch"
+    )
+
+    # Require identity platform to be active so OAuth setup can succeed
+    await gather(
+        ops_test.model.wait_for_idle(status="active"),
+        microk8s_model.wait_for_idle(status="active", timeout=600),
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_setup_oauth(ops_test: OpsTest, microk8s_model: Model):
+    """Configure new OAuth client on Hydra (identity platform).
+
+    Also, acquire corresponding access token for the further testing.
+    """
+    # Ensure Hydra is active before running the action
+    await microk8s_model.wait_for_idle(apps=["hydra"], status="active", timeout=300)
+
+    action: Action = (
+        await microk8s_model.applications["hydra"]
+        .units[0]
+        .run_action(
+            "create-oauth-client",
+            **{
+                "scope": ["openid", "profile", "email", "phone", "offline"],
+                "grant-types": ["client_credentials"],
+                "audience": ["opensearch"],
+            },
+        )
+    )
+    await action.wait()
+    global oauth_client_id
+    oauth_client_id = action.results.get("client-id")
+    oauth_client_secret = action.results.get("client-secret")
+    if not (oauth_client_id and oauth_client_secret):
+        msg = (
+            "failed to retrieve oauth client id and secret from hydra; "
+            f"action status={getattr(action, 'status', 'unknown')}, "
+            f"results={action.results}"
+        )
+        raise AssertionError(msg)
+
+    action = (
+        await microk8s_model.applications["traefik-public"]
+        .units[0]
+        .run_action("show-proxied-endpoints")
+    )
+    await action.wait()
+    result = json.loads(action.results.get("proxied-endpoints", "{}"))
+    hydra_url = result.get("hydra", {}).get("url")
+    assert hydra_url, "failed to retrieve hydra url from traefik"
+
+    result = requests.post(
+        f"{hydra_url}/oauth2/token",
+        {"scope": "openid", "grant_type": "client_credentials", "audience": "opensearch"},
+        auth=requests.auth.HTTPBasicAuth(oauth_client_id, oauth_client_secret),
+        verify=False,
+    )
+    global oauth_access_token
+    oauth_access_token = result.json().get("access_token")
+    assert oauth_access_token, "failed to retrieve access token from hydra"
+
+
+@pytest.mark.abort_on_fail
+async def test_oauth_access(ops_test: OpsTest, microk8s_model: Model):
+    """Check access to the OpenSearch with an access token, acquired earlier.
+
+    Ensure that roles mapping works correctly by elevating user
+    to the admin role and checking access to the admin endpoint.
+    """
+    global opensearch_address
+    opensearch_address = await get_leader_unit_ip(ops_test, "opensearch")
+    opensearch_url = f"https://{opensearch_address}:9200/_cat/indices"
+    result = requests.get(
+        opensearch_url, headers={"Authorization": f"Bearer {oauth_access_token}"}, verify=False
+    )
+    assert result.json().get("status") == 403, "no permissions error expected"
+
+    action = (
+        await ops_test.model.applications[DATA_INTEGRATOR_NAME]
+        .units[0]
+        .run_action("get-credentials")
+    )
+    await action.wait()
+    data_integrator_user = action.results.get("opensearch", {}).get("username")
+    assert data_integrator_user, "failed to retrieve data integrator user"
+
+    global original_opensearch_config
+    original_opensearch_config = await ops_test.model.applications["opensearch"].get_config()
+    config_with_roles = original_opensearch_config.copy()
+    config_with_roles["roles_mapping"] = json.dumps({oauth_client_id: data_integrator_user})
+    await ops_test.model.applications["opensearch"].set_config(config_with_roles)
+    await ops_test.model.wait_for_idle(status="active")
+
+    result = requests.get(
+        opensearch_url, headers={"Authorization": f"Bearer {oauth_access_token}"}, verify=False
+    )
+    assert result.status_code == 200, "request expected to succeed with roles mapping"
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_second_client(ops_test: OpsTest, microk8s_model: Model):
+    """Deploy and configure second data integrator."""
+    await ops_test.model.deploy(
+        DATA_INTEGRATOR_NAME,
+        application_name=SECOND_DATA_INTEGRATOR_NAME,
+        config=SECOND_DATA_INTEGRATOR_CONFIG,
+    )
+    await ops_test.model.wait_for_idle()
+    await ops_test.model.integrate(SECOND_DATA_INTEGRATOR_NAME, "opensearch")
+    await ops_test.model.wait_for_idle()
+
+
+@pytest.mark.abort_on_fail
+async def test_oauth_access_second_client(ops_test: OpsTest, microk8s_model: Model):
+    """Change roles mapping from first data integrator user to second one.
+
+    Ensure, that admin permissions from the first one is removed, while role
+    from the second one is added.
+    """
+    action = (
+        await ops_test.model.applications[SECOND_DATA_INTEGRATOR_NAME]
+        .units[0]
+        .run_action("get-credentials")
+    )
+    await action.wait()
+    second_data_integrator_user = action.results.get("opensearch", {}).get("username")
+    assert second_data_integrator_user, "failed to retrieve second data integrator user"
+
+    config_with_roles = original_opensearch_config.copy()
+    config_with_roles["roles_mapping"] = json.dumps({oauth_client_id: second_data_integrator_user})
+    await ops_test.model.applications["opensearch"].set_config(config_with_roles)
+    await ops_test.model.wait_for_idle(status="active")
+
+    # Ensure first data integrator admin role is removed
+    result = requests.get(
+        f"https://{opensearch_address}:9200/_cat/indices",
+        headers={"Authorization": f"Bearer {oauth_access_token}"},
+        verify=False,
+    )
+    assert (
+        result.json().get("status") == 403
+    ), "no permissions error expected as admin role should be removed"
+
+    # Ensure second data integrator role is configured
+    result = requests.get(
+        f"https://{opensearch_address}:9200/_plugins/_security/authinfo",
+        headers={"Authorization": f"Bearer {oauth_access_token}"},
+        verify=False,
+    )
+    assert result.status_code == 200, "request for authinfo should success"
+    assert sorted(result.json().get("roles")) == sorted(
+        [
+            "own_index",
+            second_data_integrator_user,
+        ]
+    ), "second data integrator role should be enabled"
+
+
+@pytest.mark.abort_on_fail
+async def test_oauth_access_cleanup(ops_test: OpsTest, microk8s_model: Model):
+    """Ensure that all of the oauth clients permissions are removed with clean roles mapping."""
+    await ops_test.model.applications["opensearch"].set_config(original_opensearch_config)
+    await ops_test.model.wait_for_idle(status="active")
+
+    result = requests.get(
+        f"https://{opensearch_address}:9200/_plugins/_security/authinfo",
+        headers={"Authorization": f"Bearer {oauth_access_token}"},
+        verify=False,
+    )
+    assert result.status_code == 200, "request for authinfo should success"
+    assert result.json().get("roles") == ["own_index"], "all the mapped roles should be removed"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9182")
+async def test_setup_large_cluster(ops_test: OpsTest, charm, series, microk8s_model: Model):
+    """Replace the Opensearch application with a large deployment cluster."""
+    logger.info("Remove Opensearch application")
+    await ops_test.model.remove_application("opensearch", block_until_done=True)
+    await ops_test.model.remove_application(SECOND_DATA_INTEGRATOR_NAME, block_until_done=True)
+
+    logger.info("Create large deployment cluster of Opensearch")
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            application_name=MAIN_APP,
+            num_units=APP_UNITS[MAIN_APP],
+            series=series,
+            config={"cluster_name": CLUSTER_NAME, "roles": "cluster_manager"} | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=FAILOVER_APP,
+            num_units=APP_UNITS[FAILOVER_APP],
+            series=series,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "cluster_manager"}
+            | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=DATA_APP,
+            num_units=APP_UNITS[DATA_APP],
+            series=series,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "data"}
+            | CONFIG_OPTS,
+        ),
+    )
+
+    # integrate TLS to all applications
+    for app in [MAIN_APP, FAILOVER_APP, DATA_APP]:
+        await ops_test.model.integrate(app, "certificates")
+
+    # integrate large deployment cluster
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}")
+
+    # integrate with Data integrator
+    await ops_test.model.integrate(
+        f"{DATA_APP}:opensearch-client", f"{DATA_INTEGRATOR_NAME}:opensearch"
+    )
+
+    # Let Juju settle while the cluster forms TLS + security index + peer orchestration
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP, FAILOVER_APP, DATA_INTEGRATOR_NAME],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {"active": []},
+            FAILOVER_APP: {"active": []},
+            DATA_INTEGRATOR_NAME: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+    )
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9182")
+async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, microk8s_model: Model):
+    """Ensure OAuth cannot be enabled if related to non-main-orchestrator."""
+    logger.info(f"Integrating {DATA_APP} with OAuth - this will result in blocked status")
+    await ops_test.model.integrate(f"{DATA_APP}:oauth", "oauth")
+    await wait_until(
+        ops_test,
+        apps=[DATA_APP],
+        apps_full_statuses={
+            DATA_APP: {"blocked": [CharmStatuses.OAUTH_RELATION_INVALID.value.message]},
+        },
+        wait_for_exact_units={DATA_APP: 3},
+    )
+
+    logger.info("Verifying access is not possible")
+    opensearch_address = await get_leader_unit_ip(ops_test, DATA_APP)
+    opensearch_url = f"https://{opensearch_address}:9200/_cat/indices"
+    result = requests.get(
+        opensearch_url, headers={"Authorization": f"Bearer {oauth_access_token}"}, verify=False
+    )
+    assert result.status_code == 401, "`Unauthorized` error expected"
+    logger.info("Access with OAuth Token failed as expected")
+
+    logger.info(f"Remove relation with {DATA_APP}")
+    remove_relation_cmd = f"remove-relation {DATA_APP}:oauth oauth"
+    await ops_test.juju(*remove_relation_cmd.split(), check=True)
+
+    await wait_until(
+        ops_test,
+        apps=[DATA_APP],
+        apps_full_statuses={DATA_APP: {"active": []}},
+        units_statuses=["active"],
+        wait_for_exact_units={DATA_APP: 3},
+    )
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9182")
+async def test_oauth_access_large_cluster(ops_test: OpsTest, charm, series, microk8s_model: Model):
+    """Relate to main orchestrator and verify access with OAuth."""
+    logger.info(f"Integrating {MAIN_APP} with oauth")
+    await ops_test.model.integrate(f"{MAIN_APP}:oauth", "oauth")
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {"active": []},
+            FAILOVER_APP: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+    )
+
+    action = (
+        await ops_test.model.applications[DATA_INTEGRATOR_NAME]
+        .units[0]
+        .run_action("get-credentials")
+    )
+    await action.wait()
+    data_integrator_user = action.results.get("opensearch", {}).get("username")
+    assert data_integrator_user, "failed to retrieve data integrator user"
+
+    original_opensearch_config = await ops_test.model.applications[DATA_APP].get_config()
+    config_with_roles = original_opensearch_config.copy()
+    config_with_roles["roles_mapping"] = json.dumps({oauth_client_id: data_integrator_user})
+    await ops_test.model.applications[DATA_APP].set_config(config_with_roles)
+    await ops_test.model.wait_for_idle(status="active")
+
+    opensearch_address = await get_leader_unit_ip(ops_test, DATA_APP)
+    opensearch_url = f"https://{opensearch_address}:9200/_cat/indices"
+    result = requests.get(
+        opensearch_url, headers={"Authorization": f"Bearer {oauth_access_token}"}, verify=False
+    )
+    assert result.status_code == 200, "request expected to succeed with roles mapping"

--- a/tests/integration/tls/__init__.py
+++ b/tests/integration/tls/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/spread/vm/test_relations_jwt.py/task.yaml
+++ b/tests/spread/vm/test_relations_jwt.py/task.yaml
@@ -1,0 +1,9 @@
+summary: test_relations_jwt.py
+environment:
+  TEST_MODULE: relations/test_jwt.py
+systems:
+  - self-hosted-linux-amd64-noble-xlarge
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/vm/test_relations_oauth.py/task.yaml
+++ b/tests/spread/vm/test_relations_oauth.py/task.yaml
@@ -1,0 +1,9 @@
+summary: test_relations_oauth.py
+environment:
+  TEST_MODULE: relations/test_oauth.py
+systems:
+  - self-hosted-linux-amd64-noble-xlarge
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results


### PR DESCRIPTION
This PR depends on #24.

# Key changes

## JWT

* Ported JWT events handler.
* The `get_object` & `put_object` functions were moved from `ApplicationState` to the `RelationState` base class in order to bring that functionality to both application & server contexts. It is used by `jwt_auth_configuration` state property.

## OAuth

* Ported OAuth events handler.
* Added OAuth charm library, on which events handler is dependent.

## Config manager

* Refactored config manager to reconcile `opensearch-security/config.yml` config instead of updating it in different places, that will improve codebase readability. This actually completes a full config manager refactor.
* All of the default security plugins are preserved in opensearch security to avoid any functional difference between OG and single-kernel Opensearch charms.

## Paths

* Moved `Paths.certs / "chain.pem"` path to `Paths.certs_chain` property.
* Modified TLS & config manager to use new path property.
* Modified Opensearch client to use new path property.

## Cluster manager

Ported `update_security_config` function for JWT & OAuth.