### PR TITLE
patch: Adding tics workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - self-hosted
+    - linux
+    - amd64
+    - tiobe
+    - noble

--- a/.github/workflows/tics_run.yaml
+++ b/.github/workflows/tics_run.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tics-scan:
-    runs-on: [self-hosted, noble, tiobe]
+    runs-on: [self-hosted, linux, amd64, tiobe, noble]
 
     steps:
       - name: Checkout the project

--- a/.github/workflows/tics_run.yaml
+++ b/.github/workflows/tics_run.yaml
@@ -1,0 +1,54 @@
+name: TICS run self-hosted test
+
+on:
+    schedule:
+        - cron: '0 2 * * 6' # Every Saturday 2:00 AM UTC
+    workflow_dispatch: # Allows manual triggering
+
+jobs:
+  tics-scan:
+    runs-on: [self-hosted, noble, tiobe]
+
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3-venv build-essential libldap-dev libsasl2-dev
+
+      - name: Install pipx
+        run: sudo apt install -y pipx && pipx ensurepath
+
+      - name: Add pipx to PATH
+        run: echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Install tox and poetry using pipx
+        run: |
+          pipx install tox
+          pipx install poetry
+
+      - name: Activate virtual environment and install dependencies
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          poetry install --all-groups
+          pipx install pylint flake8
+          echo "PATH=$PATH" >> "$GITHUB_PATH"
+
+      - name: Run tox unit tests to create coverage.xml
+        run: tox run -e unit-vm
+
+      - name: move results to necessary folder for TICS
+        run: |
+          mkdir .cover
+          mv coverage.xml .cover/coverage.xml
+
+      - name: Run TICS analysis with github-action
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: opensearch-single-kernel-library
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/.github/workflows/tics_run.yaml
+++ b/.github/workflows/tics_run.yaml
@@ -27,6 +27,13 @@ jobs:
           pipx install tox
           pipx install poetry
 
+      # This step is required since the configuration of aproxy on the self-hosted runner
+      # Makes the socket connections to several ip's give false positive results. This is due
+      # to the aproxy configuration that is excluding only a range of ip's
+      - name: Exclude the opensearch test host from proxy
+        run: |
+          sudo nft add element ip aproxy exclude "{ 1.1.1.1 }"
+
       - name: Activate virtual environment and install dependencies
         run: |
           python3 -m venv .venv


### PR DESCRIPTION
This PR adds the TICS Github workflow to the OpenSearch Single Kernel Repository. For the reference, a new project has been created named 'opensearch-single-kernel' in the TICS dashboard. This workflow will use the feature/single-kernel for now until the refactoring is done and we merge to 2/edge. The workflow that is being added is the same previously used for [opensearch-operator](https://github.com/canonical/opensearch-operator/) repository.

