### PR TITLE
patch: Adding SSL Adapter to not pass chain as file path 

### DIFF
--- a/opensearch_single_kernel/charms/base.py
+++ b/opensearch_single_kernel/charms/base.py
@@ -90,7 +90,7 @@ class OpenSearchBaseCharm(ops.CharmBase, ABC):
         """Stop OpenSearch service."""
         self.status.set(CharmStatuses.SERVICE_IS_STOPPING)
 
-        if self.cluster_manager.opensearch_client.is_node_up():
+        if self.cluster_manager.is_node_up():
             try:
                 nodes = self.cluster_manager.get_nodes(True)
                 # do not add exclusions if it's the last unit to stop

--- a/opensearch_single_kernel/common/client.py
+++ b/opensearch_single_kernel/common/client.py
@@ -24,7 +24,7 @@ from tenacity.wait import WaitBaseT
 
 from opensearch_single_kernel.common.exceptions import OpenSearchHttpError
 from opensearch_single_kernel.core.models import App, Node
-from opensearch_single_kernel.workload.base import BaseWorkload
+from opensearch_single_kernel.utils.requests import SSLStringAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class OpenSearchClient:
     """Handle OpenSearch Interaction with Server."""
 
     def __init__(
-        self, workload: BaseWorkload, host: str, port: int, admin_secret: str | None = None
+        self, host: str, port: int, admin_secret: str | None = None, ca_chain: str | None = None
     ):
         """Initialise the client.
 
@@ -41,8 +41,8 @@ class OpenSearchClient:
         """
         self.host = host
         self.port = port
-        self.workload = workload
         self.admin_secret = admin_secret
+        self.ca_chain = ca_chain
 
     def flush_translog(self, alt_hosts: list[str] | None = None) -> None:
         """Flush the OpenSearch translog to ensure all operations are committed to disk."""
@@ -403,16 +403,11 @@ class OpenSearchClient:
         """Call the /_nodes API endpoint of opensearch"""
         return self.request("GET", "/_nodes", host=host, alt_hosts=alt_hosts, retries=3)
 
-    def is_node_up(self, host: str | None = None) -> bool:
-        """Get status of node.
+    def is_opensearch_api_up(self, host: str) -> bool:
+        """Get status of OpenSearch API
 
-        This assumes OpenSearch is Running. Defaults to this unit
+        This assumes OpenSearch is Reachable. Defaults to this unit
         """
-        # This function needs to give us a quick response
-        host = host or self.host
-        if not self.workload.is_reachable(host, self.port):
-            return False
-
         try:
             resp_code = self.request(
                 "GET",
@@ -480,11 +475,13 @@ class OpenSearchClient:
                         s.cert = cert_files
                     else:
                         s.auth = ("admin", self.admin_secret)
-                    # TODO: Handle this when implementing the k8s version of start workflow.
+
+                    if self.ca_chain:
+                        s.mount(url, SSLStringAdapter(self.ca_chain))
+
                     request_kwargs = {
                         "method": method.upper(),
                         "url": url,
-                        "verify": f"{self.workload.paths.certs}/chain.pem",
                         "headers": {
                             "Accept": "application/json",
                             "Content-Type": "application/json",
@@ -519,7 +516,7 @@ class OpenSearchClient:
 
         urls = []
         for host_candidate in (host or self.host, *(alt_hosts or [])):
-            if check_hosts_reach and not self.is_node_up(host_candidate):
+            if check_hosts_reach and not self.is_opensearch_api_up(host_candidate):
                 continue
             urls.append(f"https://{host_candidate}:{self.port}/{endpoint}")
         if not urls:

--- a/opensearch_single_kernel/events/opensearch.py
+++ b/opensearch_single_kernel/events/opensearch.py
@@ -153,7 +153,7 @@ class OpenSearchEventsHandler(Object):
             event.defer()
             return
 
-        if is_node_up := self.charm.cluster_manager.opensearch_client.is_node_up():
+        if is_node_up := self.charm.cluster_manager.is_node_up():
             health = self.charm.status.apply_health(app=self.charm.unit.is_leader())
 
             if health in [HealthColors.UNKNOWN, HealthColors.YELLOW_TEMP]:
@@ -219,7 +219,7 @@ class OpenSearchEventsHandler(Object):
         if not (self.charm.unit.is_leader() and len(event.relation.units) > 0):
             return
 
-        if not self.charm.cluster_manager.opensearch_client.is_node_up():
+        if not self.charm.cluster_manager.is_node_up():
             logger.debug("Node is not up. Deferring event.")
             event.defer()
             return
@@ -294,8 +294,7 @@ class OpenSearchEventsHandler(Object):
                     raise OpenSearchHAError(CharmStatuses.CLUSTER_HEALTH_RED.value.message)
         finally:
             if planned_units > 1 and (
-                self.charm.cluster_manager.opensearch_client.is_node_up()
-                or self.charm.cluster_manager.alt_hosts
+                self.charm.cluster_manager.is_node_up() or self.charm.cluster_manager.alt_hosts
             ):
                 # release lock
                 self.charm.lock_manager.release()
@@ -319,7 +318,7 @@ class OpenSearchEventsHandler(Object):
             return
 
         # if node already shutdown - leave
-        if not self.charm.cluster_manager.opensearch_client.is_node_up():
+        if not self.charm.cluster_manager.is_node_up():
             return
 
         # review available CMs
@@ -365,7 +364,7 @@ class OpenSearchEventsHandler(Object):
             and self.charm.state.ca_and_certs_rotation_complete_in_cluster()
         ):
             logger.debug("update_status: Detected CA rotation complete in cluster")
-            self.charm.tls_manager.finalize_ca_certs_rotation()
+            self.charm.tls_manager.remove_old_ca()
         # If relation not broken - leave
         if self.charm.state.tls_relation:
             return
@@ -467,7 +466,7 @@ class OpenSearchEventsHandler(Object):
 
         if self.charm.state.application.is_security_index_initialised:
             # Leader election event happening after a previous leader got killed
-            if not self.charm.cluster_manager.opensearch_client.is_node_up():
+            if not self.charm.cluster_manager.is_node_up():
                 event.defer()
                 return
 
@@ -510,7 +509,7 @@ class OpenSearchEventsHandler(Object):
 
     def _on_start(self, event: StartEvent) -> None:  # noqa: C901
         """Event handler for start event."""
-        if self.charm.cluster_manager.opensearch_client.is_node_up():
+        if self.charm.cluster_manager.is_node_up():
             self.cleanup_start_state()
             return
 
@@ -1074,7 +1073,7 @@ class OpenSearchEventsHandler(Object):
             and self.charm.state.ca_and_certs_rotation_complete_in_cluster()
         ):
             logger.info("post_start_init: Detected CA rotation complete in cluster")
-            self.charm.tls_manager.finalize_ca_certs_rotation()
+            self.charm.tls_manager.remove_old_ca()
 
         # TODO: Handle case of peer cluster manager
         # if self.peers_data.get(Scope.UNIT, "cluster_manager_removed", default=False):

--- a/opensearch_single_kernel/events/tls.py
+++ b/opensearch_single_kernel/events/tls.py
@@ -228,19 +228,9 @@ class TLSEventsHandler(Object):
             self.charm.state.secrets.get_object(scope, cert_type.val, peek=True),
         )
 
-        # apply the chain.pem file for API requests, only if the CA cert has not been updated
         admin_secrets = (
             self.charm.state.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val, peek=True) or {}
         )
-        if admin_secrets.get("chain") and not self.charm.tls_manager.read_stored_ca(
-            alias=OLD_CA_ALIAS
-        ):
-            try:
-                self.charm.tls_manager.update_request_ca_bundle()
-            except OpenSearchFileOperationError as e:
-                logger.debug(f"Error while updating request CA bundle: {e}")
-                event.defer()
-                return
 
         # store the admin certificates in non-leader units
         # if admin cert not available we need to defer, otherwise it will never be stored
@@ -364,7 +354,7 @@ class TLSEventsHandler(Object):
                         and self.charm.state.ca_and_certs_rotation_complete_in_cluster()
                     ):
                         logger.info("on_tls_conf_set: Detected CA rotation complete in cluster")
-                        self.charm.tls_manager.finalize_ca_certs_rotation()
+                        self.charm.tls_manager.remove_old_ca()
             else:
                 logger.debug("TLS not fully configured yet, deferring event.")
                 event.defer()

--- a/opensearch_single_kernel/managers/base.py
+++ b/opensearch_single_kernel/managers/base.py
@@ -7,7 +7,11 @@ import random
 from typing import List, Optional
 
 from opensearch_single_kernel.common.client import OpenSearchClient
-from opensearch_single_kernel.common.constants import OPENSEARCH_HTTP_PORT, Scope
+from opensearch_single_kernel.common.constants import (
+    OPENSEARCH_HTTP_PORT,
+    CertType,
+    Scope,
+)
 from opensearch_single_kernel.core.models import App, Node
 from opensearch_single_kernel.core.state import ClusterState
 from opensearch_single_kernel.utils.secrets import password_key
@@ -28,9 +32,15 @@ class BaseManager:
     def opensearch_client(self) -> OpenSearchClient:
         """Initialize an opensearch client"""
         admin_field = password_key("admin")
-        admin_secret = self.state.secrets.get(Scope.APP, admin_field)
+        admin_password = self.state.secrets.get(Scope.APP, admin_field)
+        # Get chain.pem from secrets and pass it to client
+        admin_secret = self.state.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val, peek=True)
+        ca_chain = admin_secret.get("chain")
         return OpenSearchClient(
-            self.workload, self.state.host_ip, OPENSEARCH_HTTP_PORT, admin_secret
+            self.state.host_ip,
+            OPENSEARCH_HTTP_PORT,
+            admin_password,
+            ca_chain=ca_chain,
         )
 
     @property
@@ -51,11 +61,7 @@ class BaseManager:
         if not all_hosts:
             return None
 
-        client = self.opensearch_client
-
-        return [
-            host for host in all_hosts if host != self.state.host_ip and client.is_node_up(host)
-        ]
+        return [host for host in all_hosts if host != self.state.host_ip and self.is_node_up(host)]
 
     def get_cluster_managers_ips(self, nodes: list[Node]) -> list[str]:
         """Get the nodes of cluster manager eligible nodes."""
@@ -74,6 +80,13 @@ class BaseManager:
                 result.append(node.name)
 
         return result
+
+    def is_node_up(self, host: str | None = None) -> bool:
+        """Check if a node is up."""
+        host = host or self.state.host_ip
+        if not self.workload.is_reachable(host, OPENSEARCH_HTTP_PORT):
+            return False
+        return self.opensearch_client.is_opensearch_api_up(host)
 
     def _nodes(
         self,

--- a/opensearch_single_kernel/managers/cluster.py
+++ b/opensearch_single_kernel/managers/cluster.py
@@ -69,11 +69,7 @@ class ClusterManager(BaseManager):
         """Start the opensearch service."""
 
         def _is_connected():
-            return (
-                self.opensearch_client.is_node_up()
-                if wait_until_http_200
-                else self.is_opensearch_started
-            )
+            return self.is_node_up() if wait_until_http_200 else self.is_opensearch_started
 
         if self.is_opensearch_started:
             return
@@ -315,7 +311,7 @@ class ClusterManager(BaseManager):
         """Wait for opensearch to become part of the cluster."""
         # Get online nodes
         try:
-            nodes = self.get_nodes(use_localhost=self.opensearch_client.is_node_up())
+            nodes = self.get_nodes(use_localhost=self.is_node_up())
         except OpenSearchHttpError as e:
             logger.info("Failed to get online nodes")
             raise e
@@ -391,7 +387,7 @@ class ClusterManager(BaseManager):
             reraise=True,
         ):
             with attempt:
-                if not self.opensearch_client.is_node_up():
+                if not self.is_node_up():
                     raise OpenSearchNotFullyReadyError("Node started but not fully ready yet.")
 
     def check_blocking_directives(
@@ -569,10 +565,10 @@ class ClusterManager(BaseManager):
 
         This is only run on leader unit before a unit is removed.
         """
-        if not is_last_unit and (self.opensearch_client.is_node_up() or self.alt_hosts):
+        if not is_last_unit and (self.is_node_up() or self.alt_hosts):
             remaining_nodes = [
                 node
-                for node in self.get_nodes(self.opensearch_client.is_node_up())
+                for node in self.get_nodes(self.is_node_up())
                 if node.name
                 != format_unit_name(
                     self.state.unit_name, app=self.state.application.deployment_desc.app
@@ -612,7 +608,7 @@ class ClusterManager(BaseManager):
 
     def flush_translog_to_disk(self) -> None:
         """Flush OpenSearch translog to disk."""
-        if self.opensearch_client.is_node_up():
+        if self.is_node_up():
             try:
                 self.opensearch_client.flush_translog(self.alt_hosts)
             except OpenSearchHttpError:

--- a/opensearch_single_kernel/managers/lock.py
+++ b/opensearch_single_kernel/managers/lock.py
@@ -279,7 +279,7 @@ class LockManager(PeerLockManager):
         Returns:
             Whether lock was acquired
         """
-        host = self.state.host_ip if self.opensearch_client.is_node_up() else None
+        host = self.state.host_ip if self.is_node_up() else None
         alt_hosts = self.alt_hosts
         if host or alt_hosts:
             logger.debug("[Node lock] 1+ opensearch nodes online")
@@ -403,7 +403,7 @@ class LockManager(PeerLockManager):
         # fetch current app description
         current_app = self.state.application.deployment_desc.app
 
-        host = self.state.host_ip if self.opensearch_client.is_node_up() else None
+        host = self.state.host_ip if self.is_node_up() else None
         alt_hosts = self.alt_hosts
         if host or alt_hosts:
             logger.debug("[Node lock] Checking which unit has opensearch lock")

--- a/opensearch_single_kernel/managers/tls.py
+++ b/opensearch_single_kernel/managers/tls.py
@@ -306,25 +306,6 @@ class TlsManager(BaseManager):
 
         return None
 
-    def update_request_ca_bundle(self, ca_chain: str | None = None) -> None:
-        """Create a new chain.pem file for requests module"""
-        logger.debug("Updating requests TLS CA bundle")
-        if ca_chain is None:
-            admin_secret = self.state.secrets.get_object(
-                Scope.APP, CertType.APP_ADMIN.val, peek=True
-            )
-            ca_chain = admin_secret.get("chain")
-
-        # we store the pem format to make it easier for the python requests lib
-        chain_path = self.workload.paths.certs / "chain.pem"
-        if parent_dir_path := chain_path.parent:
-            self.workload.mkdir(parent_dir_path, parents=True, exist_ok=True)
-
-        # if the chain.pem already contains the current CA chain, we can skip rewriting it
-        bundle_content = self.workload.read_text(chain_path) if chain_path.exists() else ""
-        if ca_chain not in bundle_content:
-            self.workload.write_text(f"{bundle_content}\n{ca_chain}", chain_path)
-
     def _remove_ca_from_request_bundle(self, ca_cert: str) -> None:
         """Remove the CA cert from the request bundle for the requests module."""
         bundle_path = self.workload.paths.certs / "chain.pem"
@@ -469,12 +450,6 @@ class TlsManager(BaseManager):
                 cert_files=(str(tmp_cert), str(tmp_key))
             )
 
-    def finalize_ca_certs_rotation(self) -> None:
-        """Handle the completion of CA rotation."""
-        logger.info("CA rotation completed. Deleting old CA and updating request bundle.")
-        self.remove_old_ca()
-        self.update_request_ca_bundle()
-
     def get_unit_certificates(self) -> dict[CertType, str]:
         """Retrieve the list of certificates for this unit."""
         certs = {}
@@ -559,7 +534,5 @@ class TlsManager(BaseManager):
             keep_previous=True,
         ):
             return False
-
-        self.update_request_ca_bundle(secrets.get("chain"))
 
         return True

--- a/opensearch_single_kernel/utils/requests.py
+++ b/opensearch_single_kernel/utils/requests.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utilities for requests."""
+import ssl
+
+from requests.adapters import HTTPAdapter
+
+
+class SSLStringAdapter(HTTPAdapter):
+    """Custom Transport Adapter that loads SSL certificates directly from a string."""
+
+    def __init__(self, cert_string, **kwargs):
+        """Initialize the adapter with the certificate string."""
+        self.cert_string = cert_string
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        """Initialize the pool manager with a custom SSL context."""
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.check_hostname = True
+        try:
+            context.load_verify_locations(cadata=self.cert_string)
+        except Exception as e:
+            print(f"Error loading certificate string: {e}")
+            raise
+        # Pass the context into the pool manager
+        pool_kwargs["ssl_context"] = context
+        return super().init_poolmanager(connections, maxsize, block, **pool_kwargs)

--- a/opensearch_single_kernel/utils/requests.py
+++ b/opensearch_single_kernel/utils/requests.py
@@ -16,7 +16,7 @@ class SSLStringAdapter(HTTPAdapter):
         self.cert_string = cert_string
         super().__init__(**kwargs)
 
-    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs) -> None:
         """Initialize the pool manager with a custom SSL context."""
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         context.verify_mode = ssl.CERT_REQUIRED

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -160,7 +160,9 @@ def test_on_start(harness, mocker):
         "opensearch_single_kernel.events.opensearch.OpenSearchEventsHandler._post_start_init"
     )
 
-    is_node_up = mocker.patch("opensearch_single_kernel.common.client.OpenSearchClient.is_node_up")
+    is_node_up = mocker.patch(
+        "opensearch_single_kernel.managers.cluster.ClusterManager.is_node_up"
+    )
     mocker.patch("opensearch_single_kernel.workload.vm.VMWorkload.is_service_started")
 
     # test when setup complete

--- a/tests/unit/test_tls_manager.py
+++ b/tests/unit/test_tls_manager.py
@@ -747,9 +747,6 @@ def test_on_certificate_available_ca_rotation_first_stage_any_cluster_leader(
         "opensearch_single_kernel.managers.tls.TlsManager.read_stored_ca"
     )
 
-    update_request_ca_bundle = mocker.patch(
-        "opensearch_single_kernel.managers.tls.TlsManager.update_request_ca_bundle"
-    )
     split_ca_chain = mocker.patch("opensearch_single_kernel.utils.certificates.split_ca_chain")
     run_cmd = mocker.patch(
         f"opensearch_single_kernel.workload.{substrate}.{substrate.upper()}Workload.run_cmd"
@@ -796,8 +793,6 @@ def test_on_certificate_available_ca_rotation_first_stage_any_cluster_leader(
 
     split_ca_chain.return_value = ["new_ca"]
     harness.charm.tls_events._on_certificate_available(event_mock)
-
-    update_request_ca_bundle.assert_called_once()
 
     # Old CA cert is saved with corresponding alias, new CA cert added to keystore
     assert run_cmd.call_count == 3
@@ -1423,7 +1418,6 @@ def test_on_certificate_available_ca_rotation_third_stage_any_unit_cert_unit(
     remove_ca_from_request_bundle = mocker.patch(
         "opensearch_single_kernel.managers.tls.TlsManager._remove_ca_from_request_bundle"
     )
-    mocker.patch("opensearch_single_kernel.managers.tls.TlsManager.update_request_ca_bundle")
     tempfile = mocker.patch(
         f"opensearch_single_kernel.workload.{substrate}.{substrate.upper()}Workload.temp_file"
     )
@@ -1594,7 +1588,6 @@ def test_on_certificate_available_rotation_ongoing_on_this_unit(
     read_stored_ca = mocker.patch(
         "opensearch_single_kernel.managers.tls.TlsManager.read_stored_ca"
     )
-    mocker.patch("opensearch_single_kernel.managers.tls.TlsManager.update_request_ca_bundle")
     mocker.patch(
         f"opensearch_single_kernel.workload.{substrate}.{substrate.upper()}Workload.temp_file"
     )


### PR DESCRIPTION
This Pull Request address the issue of having to pass the chain.pem path to the request each time we are calling the opensearch api. The drawback of that approach is that we had to maintain the chain.pem file whenever we are doing ca_rotation or are just creating the certificates. Another drawback is that in kubernetes the filesystem of the workload and the charm is not the same so we would need to cache the chain.pem in the charm container and make sure it is up to date. 

To address this issue the solution is to use an adapter and pass the certificate chain directly from the secrets instead of creating a file and passing the file path.