### PR TITLE
patch: spread installation

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up environment
         run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
@@ -103,7 +103,7 @@ jobs:
       # https://github.com/canonical/charmcraft/issues/2130 fixed
       - run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This pull request updates the integration test workflow to use the correct source for the `spread` tool. The `go install` command now pulls `spread` from the `canonical` organization instead of `snapcore`. This ensures the workflow uses the actively maintained and official version of `spread`.

Workflow updates:

* Updated the `go install` command in `.github/workflows/integration_test.yaml` to use `github.com/canonical/spread/cmd/spread@latest` instead of `github.com/snapcore/spread/cmd/spread@latest` in both the environment setup and job steps. [[1]](diffhunk://#diff-f61384d930ecca9b388b7d547b0c10b6c977f087b106b0747d64dad87a96daa0L23-R23) [[2]](diffhunk://#diff-f61384d930ecca9b388b7d547b0c10b6c977f087b106b0747d64dad87a96daa0L106-R106)