### PR TITLE
patch: Freeze setuptools

### DIFF
--- a/tests/charms/opensearch_test_charm/charmcraft.yaml
+++ b/tests/charms/opensearch_test_charm/charmcraft.yaml
@@ -51,12 +51,14 @@ parts:
     source: .
     after:
       - poetry-deps
-    poetry-export-extra-args: ['--only', 'main,charm-libs', '--without-hashes']
+    poetry-export-extra-args: ["--only", "main,charm-libs", "--without-hashes"]
     build-packages:
-      - git         # Needed for dunamai (dynamic versioning)
-      - libffi-dev  # Needed to build Python dependencies with Rust from source
-      - libssl-dev  # Needed to build Python dependencies with Rust from source
-      - pkg-config  # Needed to build Python dependencies with Rust from source
+      - git # Needed for dunamai (dynamic versioning)
+      - libffi-dev # Needed to build Python dependencies with Rust from source
+      - libssl-dev # Needed to build Python dependencies with Rust from source
+      - pkg-config # Needed to build Python dependencies with Rust from source
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt # Workaround setuptools 82
     override-build: |
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
@@ -77,6 +79,7 @@ parts:
       rustup set profile minimal
       rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
+      echo "setuptools-scm<10.0.0" > constraints.txt
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"


### PR DESCRIPTION
This pull request makes minor improvements to the `charmcraft.yaml` configuration for the `opensearch_test_charm` test charm. The changes focus on improving dependency management and build reliability by introducing a workaround for a known `setuptools` issue.

Dependency management and build environment improvements:

* Added a `build-environment` variable to set the `PIP_CONSTRAINT` environment variable to `constraints.txt`, providing a workaround for `setuptools` 82 compatibility issues.
* Added a step to create a `constraints.txt` file that pins `setuptools-scm` to a version below 10.0.0, further ensuring compatibility during the build process.