### PR TITLE
patch: Add platform and refactor the build script a little

### DIFF
--- a/scripts/build_lib_for_integration.sh
+++ b/scripts/build_lib_for_integration.sh
@@ -4,34 +4,70 @@
 
 set -e
 
-# Helper function to avoid code duplication
-pack_charm() {
-    if ${CI_CACHE:-false}; then
-        ccc pack -v
-    else
-        charmcraft pack -v
-    fi
-}
-
-git_hash=$(git describe --always --dirty)
+# --- Variables ---
+PLATFORM=""
+declare -a TEST_CHARMS=()
 
 LIB_PATH="./opensearch_single_kernel"
-
 CHARMS_PATH="./tests/charms"
 THIRD_PARTY_CHARMS=("./tests/integration/relations/opensearch_provider/application-charm")
 
-if [ $# -ge 1 ]; then
-    declare -a TEST_CHARMS=("$1")
-else
-    declare -a TEST_CHARMS=("${CHARMS_PATH}/opensearch_test_charm" )
+# --- Argument Parsing ---
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -p|--platform)
+            PLATFORM="$2"
+            shift 2
+            ;;
+        -c|--charm)
+            TEST_CHARMS+=("$2")
+            shift 2
+            ;;
+        *)
+            # Maintain backward compatibility for an unnamed first parameter as the charm
+            if [[ "$1" != -* ]] && [ ${#TEST_CHARMS[@]} -eq 0 ]; then
+                TEST_CHARMS+=("$1")
+                shift
+            else
+                echo "Unknown parameter passed: $1"
+                echo "Usage: $0 [-p|--platform <platform>] [-c|--charm <charm_path>] [charm_path]"
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+# Default to opensearch_test_charm if no charms were specified
+if [ ${#TEST_CHARMS[@]} -eq 0 ]; then
+    TEST_CHARMS=("${CHARMS_PATH}/opensearch_test_charm")
 fi
+
+# --- Helper Functions ---
+pack_charm() {
+    # Store arguments in an array to safely handle spaces or empty strings
+    local pack_args=("-v")
+    
+    # Inject platform argument if one was provided
+    if [ -n "$PLATFORM" ]; then
+        pack_args+=("--platform" "$PLATFORM")
+    fi
+
+    if ${CI_CACHE:-false}; then
+        ccc pack "${pack_args[@]}"
+    else
+        charmcraft pack "${pack_args[@]}"
+    fi
+}
+
+# --- Main Logic ---
+git_hash=$(git describe --always --dirty)
 
 for directory in "${TEST_CHARMS[@]}"; do
 
     # Pack the third party charms
     if [[ " ${THIRD_PARTY_CHARMS[*]} " =~ ${directory} ]]; then
-        echo "Packing third party charm ${directory}\n"
-        pushd $directory
+        echo -e "Packing third party charm ${directory}\n"
+        pushd "$directory"
         pack_charm
         popd
     else
@@ -39,15 +75,15 @@ for directory in "${TEST_CHARMS[@]}"; do
         directory_lib_path="${directory}/${LIB_PATH}"
         rm -rf "$directory_lib_path"
         mkdir "$directory_lib_path"
+        
         echo "copying over libs from single kernel charm"
-        cp -r "${LIB_PATH}" "$directory_lib_path"
+        cp -r "${LIB_PATH}/" "$directory_lib_path/"
         cp "pyproject.toml" "$directory_lib_path"
         cp "README.md" "$directory_lib_path"
 
-        echo "Building charm ${directory}\n"
+        echo -e "Building charm ${directory}\n"
 
-
-        pushd $directory
+        pushd "$directory"
 
         # Backup files
         cp pyproject.toml pyproject.toml.backup
@@ -69,7 +105,7 @@ for directory in "${TEST_CHARMS[@]}"; do
 
         # Cleanup
         echo "removing copied files from single kernel charm."
-        rm ${LIB_PATH} -rf
+        rm -rf "${LIB_PATH}"
         mv charm_version.backup charm_version
         mv pyproject.toml.backup pyproject.toml
         mv poetry.lock.backup poetry.lock

--- a/scripts/build_lib_for_integration.sh
+++ b/scripts/build_lib_for_integration.sh
@@ -46,7 +46,7 @@ fi
 pack_charm() {
     # Store arguments in an array to safely handle spaces or empty strings
     local pack_args=("-v")
-    
+
     # Inject platform argument if one was provided
     if [ -n "$PLATFORM" ]; then
         pack_args+=("--platform" "$PLATFORM")
@@ -75,7 +75,7 @@ for directory in "${TEST_CHARMS[@]}"; do
         directory_lib_path="${directory}/${LIB_PATH}"
         rm -rf "$directory_lib_path"
         mkdir "$directory_lib_path"
-        
+
         echo "copying over libs from single kernel charm"
         cp -r "${LIB_PATH}/" "$directory_lib_path/"
         cp "pyproject.toml" "$directory_lib_path"


### PR DESCRIPTION
This pull request refactors and improves the `scripts/build_lib_for_integration.sh` script, making it more flexible and robust for building and packaging charms. The main enhancements include better argument parsing, support for specifying platforms and multiple charms, improved handling of third-party charms, and safer file operations.

**Argument parsing and flexibility improvements:**

* Added support for `-p|--platform` and `-c|--charm` options, enabling users to specify the target platform and multiple charms to build. The script also maintains backward compatibility for unnamed parameters.
* Defaults to building the `opensearch_test_charm` if no charm is specified, improving usability.

**Packaging and build process enhancements:**

* Refactored the `pack_charm` function to safely handle arguments and inject the platform if specified. The function now uses arrays for argument safety and supports both `ccc` and `charmcraft` based on the `CI_CACHE` variable.
* Improved handling and messaging for third-party charms, using `echo -e` for clearer output and quoting variables for safety.

**File operation safety and cleanup:**

* Ensured all file and directory operations (copy, remove, pushd/popd) use quoted variables to prevent issues with paths containing spaces. [[1]](diffhunk://#diff-27d30c7f5dfda11272a2d0903a73df812831930e550f8ce717d1c6997f727922L7-R86) [[2]](diffhunk://#diff-27d30c7f5dfda11272a2d0903a73df812831930e550f8ce717d1c6997f727922L72-R108)
* Fixed the cleanup command to use the correct `rm -rf "${LIB_PATH}"` syntax, ensuring robust removal of copied libraries.