### PR TITLE
patch: [DPE-9180] Upgrades

### DIFF
--- a/opensearch_single_kernel/charms/base.py
+++ b/opensearch_single_kernel/charms/base.py
@@ -32,6 +32,7 @@ from opensearch_single_kernel.events.custom_events import (
     ReloadKeystoreEvent,
     RestartOpenSearch,
     StartOpenSearch,
+    UpgradeOpenSearch,
     VerifySnapshotsCredentialsEvent,
 )
 from opensearch_single_kernel.events.external_clients import (
@@ -44,6 +45,7 @@ from opensearch_single_kernel.events.oauth import OAuthEventsHandler
 from opensearch_single_kernel.events.opensearch import OpenSearchEventsHandler
 from opensearch_single_kernel.events.snapshots import SnapshotsEventsHandler
 from opensearch_single_kernel.events.tls import TLSEventsHandler
+from opensearch_single_kernel.events.upgrades import UpgradesEventsHandler
 from opensearch_single_kernel.lib.charms.data_platform_libs.v0.azure_storage import (
     AzureStorageRequires,
 )
@@ -65,6 +67,7 @@ from opensearch_single_kernel.managers.plugin import PluginManager
 from opensearch_single_kernel.managers.profiles import ProfilesManager
 from opensearch_single_kernel.managers.snapshots import SnapshotsManager
 from opensearch_single_kernel.managers.tls import TlsManager
+from opensearch_single_kernel.managers.upgrades_vm import UpgradesManagerVM
 from opensearch_single_kernel.workload.base import BaseWorkload
 
 logger = logging.getLogger(__name__)
@@ -76,6 +79,7 @@ class OpenSearchBaseCharm(ops.CharmBase, ABC):
     # Custom Events
     restart_opensearch_event = EventSource(RestartOpenSearch)
     start_opensearch_event = EventSource(StartOpenSearch)
+    upgrade_opensearch_event = EventSource(UpgradeOpenSearch)
     verify_snapshots_credentials_event = EventSource(VerifySnapshotsCredentialsEvent)
     reload_keystore_event = EventSource(ReloadKeystoreEvent)
 
@@ -106,9 +110,11 @@ class OpenSearchBaseCharm(ops.CharmBase, ABC):
         self.plugin_manager = PluginManager(self.state, self.workload)
         self.notifications_manager = NotificationsManager(self.state, self.workload)
         self.snapshots_manager = SnapshotsManager(self.state, self.workload)
+        self.upgrades_manager = UpgradesManagerVM(self.state, self.workload)
 
         # Event Handlers
         self.opensearch_events = OpenSearchEventsHandler(self)
+        self.upgrade_events = UpgradesEventsHandler(self)
         self.tls_events = TLSEventsHandler(self)
         self.external_clients_events = ExternalClientsEventsHandler(self)
         self.keystore_events = KeystoreEventsHandler(self)
@@ -129,6 +135,7 @@ class OpenSearchBaseCharm(ops.CharmBase, ABC):
             self.internal_users_manager,
             self.external_clients_manager,
             self.notifications_manager,
+            self.upgrades_manager,
         )
 
     def trigger_peer_rel_changed(

--- a/opensearch_single_kernel/charms/vm.py
+++ b/opensearch_single_kernel/charms/vm.py
@@ -19,7 +19,7 @@ class OpenSearchVMCharm(OpenSearchBaseCharm):
     @property
     def workload(self) -> BaseWorkload:
         """Access current workload."""
-        return VMWorkload()
+        return VMWorkload(self.charm_dir)
 
     @property
     def substrate(self) -> Substrates:

--- a/opensearch_single_kernel/common/client.py
+++ b/opensearch_single_kernel/common/client.py
@@ -753,10 +753,6 @@ class OpenSearchClient:
             wait_strategy=wait_exponential(min=2),
         )
 
-    def flush(self, alt_hosts: list[str] | None = None) -> None:
-        """Flush all indices to disk."""
-        self.request("POST", "/_flush", alt_hosts=alt_hosts, retries=3)
-
     def disable_shard_allocation(self, alt_hosts: list[str] | None = None) -> None:
         """Disable shard allocation to primaries only (used before node restart/upgrade)."""
         self.request(

--- a/opensearch_single_kernel/common/client.py
+++ b/opensearch_single_kernel/common/client.py
@@ -753,6 +753,38 @@ class OpenSearchClient:
             wait_strategy=wait_exponential(min=2),
         )
 
+    def flush(self, alt_hosts: list[str] | None = None) -> None:
+        """Flush all indices to disk."""
+        self.request("POST", "/_flush", alt_hosts=alt_hosts, retries=3)
+
+    def disable_shard_allocation(self, alt_hosts: list[str] | None = None) -> None:
+        """Disable shard allocation to primaries only (used before node restart/upgrade)."""
+        self.request(
+            "PUT",
+            "/_cluster/settings",
+            payload={
+                "persistent": {
+                    "cluster.routing.allocation.enable": "primaries",
+                    "action.auto_create_index": False,
+                }
+            },
+            alt_hosts=alt_hosts,
+        )
+
+    def enable_shard_allocation(self, alt_hosts: list[str] | None = None) -> None:
+        """Re-enable full shard allocation (used after rollback or node restart)."""
+        self.request(
+            "PUT",
+            "/_cluster/settings",
+            payload={
+                "persistent": {
+                    "cluster.routing.allocation.enable": "all",
+                    "action.auto_create_index": True,
+                }
+            },
+            alt_hosts=alt_hosts,
+        )
+
     def apply_auto_replication_to_index(
         self,
         index: str,

--- a/opensearch_single_kernel/common/constants.py
+++ b/opensearch_single_kernel/common/constants.py
@@ -241,12 +241,6 @@ PROTECTED_INDEX_NAMES = [
     ".opendistro-anomaly-detection-state",
     OPENSEARCH_NODE_LOCK_INDEX,
 ]
-# TLS
-CA_ALIAS = "ca"
-OLD_CA_ALIAS = f"old-{CA_ALIAS}"
-KEYTOOL = "opensearch.keytool"
-OLD_CA_PREFIX = "old-"
-CERTS_EXPIRATION_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 DEFAULT_EXTRA_USER_ROLE = "default"
@@ -275,6 +269,7 @@ JWT_CONFIG_RELATION = "jwt-configuration"
 OAUTH_RELATION = "oauth"
 STATUS_PEERS_RELATION = "status-peers"
 SMTP_RELATION = "smtp"
+UPGRADE_RELATION = "upgrade-version-a"
 
 
 # Paths
@@ -338,3 +333,9 @@ DATA_ROLE_REMOVAL_FORBIDDEN = (
 USER_ENDPOINT = "/_plugins/_security/api/internalusers"
 USER_ROLE_ENDPOINT = "/_plugins/_security/api/roles"
 USER_ROLESMAPPING_ENDPOINT = "/_plugins/_security/api/rolesmapping"
+
+
+# Upgrades
+UPGRADES_COMPATIBILITY_MATRIX = {
+    "2.19.4": {"2.18.0", "2.19.0", "2.19.1", "2.19.2", "2.19.3"},
+}

--- a/opensearch_single_kernel/common/exceptions.py
+++ b/opensearch_single_kernel/common/exceptions.py
@@ -133,3 +133,7 @@ class OpenSearchSmtpMissingParametersError(OpenSearchError):
 
 class OpenSearchLockError(OpenSearchError):
     """Base exception for lock manager errors."""
+
+
+class OpenSearchUpgradePrecheckError(OpenSearchError):
+    """App is not ready to upgrade"""

--- a/opensearch_single_kernel/common/statuses.py
+++ b/opensearch_single_kernel/common/statuses.py
@@ -241,3 +241,48 @@ class JwtStatuses(Enum):
         status="blocked",
         message="Configuration for JWT authentication is invalid. Check and correct parameters.",
     )
+
+
+class UpgradesStatuses(Enum):
+    """Collection of charm statuses related to upgrades manager."""
+
+    UPGRADES_ACTIVE = StatusObject(
+        status="active",
+        message="OpenSearch {workload_version} running; Snap rev {snap_revision}; Charmed operator {charm_version}",
+        approved_critical_component=True,
+    )
+    UPGRADES_ACTIVE_OUTDATED = StatusObject(
+        status="active",
+        message="OpenSearch {workload_version} running; Snap rev {snap_revision} (outdated); Charmed operator {charm_version}",
+        approved_critical_component=True,
+    )
+    UPGRADES_UPGRADING = StatusObject(
+        status="maintenance",
+        message="Upgrading.",
+        approved_critical_component=True,
+    )
+    UPGRADES_WAITING_FOR_RESUME = StatusObject(
+        status="blocked",
+        message="Upgrading. Verify highest unit is healthy & run `resume upgrade action.",
+        approved_critical_component=True,
+    )
+    UPGRADES_INCOMPATIBLE = StatusObject(
+        status="blocked",
+        message="Upgrade incompatible. Rollback to previous revision with `juju refresh`.",
+        approved_critical_component=True,
+    )
+    UPGRADES_PRE_UPGRADE_CHECK_FAILED = StatusObject(
+        status="blocked",
+        message="Pre upgrade check failed: please check the logs for more details.",
+        approved_critical_component=True,
+    )
+    UPGRADES_ROLLBACK_UNSUPPORTED = StatusObject(
+        status="blocked",
+        message="Rollback unsupported. Refresh to a newer revision or consult the recovery documentation",
+        approved_critical_component=True,
+    )
+    UPGRADES_ROLLBACK_INCOMPATIBLE = StatusObject(
+        status="blocked",
+        message="Rollback incompatible. Run 'juju run <unit> force-refresh-start' with `check-compatibility` set to false to override node version and attempt startup procedure",
+        approved_critical_component=True,
+    )

--- a/opensearch_single_kernel/core/models.py
+++ b/opensearch_single_kernel/core/models.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from hashlib import md5
 from typing import Any, Iterator, Literal
 
+import poetry.core.constraints.version as poetry_version
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -38,6 +39,7 @@ from opensearch_single_kernel.common.constants import (
     StartMode,
     State,
 )
+from opensearch_single_kernel.utils.enum import BaseStrEnum
 
 logger = logging.getLogger(__name__)
 
@@ -721,3 +723,29 @@ class JWTAuthConfiguration(Model):
     required_audience: str | None = None
     required_issuer: str | None = None
     jwt_clock_skew_tolerance_seconds: int | None = None
+
+
+class UpgradeVersions(Model):
+    """Model class for the charm & workload versions used for upgrades."""
+
+    charm: str
+    workload: str
+
+    @property
+    def charm_parsed(self) -> poetry_version.Version:
+        """Parsed charm version with build version omitted."""
+        return poetry_version.Version.parse(self.charm.split("+")[0])
+
+    @property
+    def workload_parsed(self) -> poetry_version.Version:
+        """Parsed workload version."""
+        return poetry_version.Version.parse(self.workload)
+
+
+class UnitUpgradesState(BaseStrEnum):
+    """Unit state of upgrade."""
+
+    HEALTHY = "healthy"
+    RESTARTING = "restarting"  # Kubernetes only
+    UPGRADING = "upgrading"  # Machines only
+    OUTDATED = "outdated"  # Machines only

--- a/opensearch_single_kernel/core/models.py
+++ b/opensearch_single_kernel/core/models.py
@@ -13,6 +13,7 @@ import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
+from enum import IntEnum
 from hashlib import md5
 from typing import Any, Iterator, Literal
 
@@ -749,3 +750,15 @@ class UnitUpgradesState(BaseStrEnum):
     RESTARTING = "restarting"  # Kubernetes only
     UPGRADING = "upgrading"  # Machines only
     OUTDATED = "outdated"  # Machines only
+
+
+class LifecycleUnitTearingDownAndAppActive(IntEnum):
+    """Unit is tearing down and 1+ other units are NOT tearing down"""
+
+    FALSE = 0
+    TRUE = 1
+    UNKNOWN = 2
+
+    def __bool__(self) -> bool:
+        """Return bool evaluation."""
+        return self is self.TRUE

--- a/opensearch_single_kernel/core/state.py
+++ b/opensearch_single_kernel/core/state.py
@@ -321,18 +321,18 @@ class OpenSearchServer(RelationState):
         """Return whether relation broken event should be skipped."""
         return (
             self.relation.data[self.unit]
-            .get(f"{relation.data}_{relation.id}_departing", "")
+            .get(f"{relation.name}_{relation.id}_departing", "")
             .lower()
             == "true"
         )
 
     def set_relation_departing(self, relation: Relation) -> None:
         """Set whether relation broken event should be skipped."""
-        self.update({f"{relation.data}_{relation.id}_departing": "true"})
+        self.update({f"{relation.name}_{relation.id}_departing": "true"})
 
     def remove_relation_departing(self, relation: Relation) -> None:
         """Cleanup mark whether relation broken event should be skipped."""
-        self.update({f"{relation.data}_{relation.id}_departing": ""})
+        self.update({f"{relation.name}_{relation.id}_departing": ""})
 
     @property
     def transport_secrets(self) -> dict[str, str]:

--- a/opensearch_single_kernel/core/state.py
+++ b/opensearch_single_kernel/core/state.py
@@ -109,7 +109,7 @@ class OpenSearchServer(RelationState):
         data_interface: DataPeerUnitData,
         component: Unit,
         secrets: OpenSearchSecrets,
-    ):
+    ) -> None:
         super().__init__(relation, data_interface, component)
         self.unit = component
         self.secrets = secrets
@@ -317,23 +317,22 @@ class OpenSearchServer(RelationState):
         """Set or remove OAuth openid_connect_url."""
         self.update({"oauth_openid_connect_url": value or ""})
 
-    @property
-    def oauth_departing(self) -> bool:
-        """Return whether oauth relation broken event should be skipped.
+    def get_relation_departing(self, relation: Relation) -> bool:
+        """Return whether relation broken event should be skipped."""
+        return (
+            self.relation.data[self.unit]
+            .get(f"{relation.data}_{relation.id}_departing", "")
+            .lower()
+            == "true"
+        )
 
-        When current leader is unit oauth relation isn't breaking
-        even if unit receives oauth relation broken event.
-        """
-        return self.relation.data[self.unit].get("oauth_departing", "").lower() == "true"
+    def set_relation_departing(self, relation: Relation) -> None:
+        """Set whether relation broken event should be skipped."""
+        self.update({f"{relation.data}_{relation.id}_departing": "true"})
 
-    @oauth_departing.setter
-    def oauth_departing(self, value: bool):
-        """Set whether oauth relation broken event should be skipped.
-
-        When current leader is unit oauth relation isn't breaking
-        even if unit receives oauth relation broken event.
-        """
-        self.update({"oauth_departing": str(value)})
+    def remove_relation_departing(self, relation: Relation) -> None:
+        """Cleanup mark whether relation broken event should be skipped."""
+        self.update({f"{relation.data}_{relation.id}_departing": ""})
 
     @property
     def transport_secrets(self) -> dict[str, str]:
@@ -370,7 +369,7 @@ class OpenSearchApplication(RelationState):
         component: Application,
         # TODO to be removed when integrating data interfaces v1
         secrets: OpenSearchSecrets,
-    ):
+    ) -> None:
         super().__init__(relation, data_interface, component)
         self.app = component
         self.secrets = secrets
@@ -613,7 +612,7 @@ class ExternalOpenSearchClient(RelationState):
         data_interface: Data,
         component: Application,
         relation_name: str,
-    ):
+    ) -> None:
         super().__init__(relation, data_interface, component)
         self.app = component
         self.relation_name = relation_name
@@ -741,7 +740,7 @@ class LockAppState(RelationState):
         data_interface: Data,
         component: Application,
         unit_name: str,
-    ):
+    ) -> None:
         super().__init__(relation, data_interface, component)
         self._unit_name = unit_name
 
@@ -803,7 +802,7 @@ class LockServerState(RelationState):
         relation: Relation | None,
         data_interface: Data,
         component: Unit,
-    ):
+    ) -> None:
         super().__init__(relation, data_interface, component)
         self.unit = component
 
@@ -841,7 +840,7 @@ class UpgradeAppState(RelationState):
         return UpgradeVersions.from_dict(raw)
 
     @versions.setter
-    def versions(self, value: UpgradeVersions):
+    def versions(self, value: UpgradeVersions) -> None:
         """Set the versions of installed OpenSearch in the relation bag.
 
         Used after next upgrade to check compatibility (i.e. whether that upgrade should be
@@ -878,7 +877,7 @@ class UpgradeServerState(RelationState):
         relation: Relation | None,
         data_interface: Data,
         component: Unit,
-    ):
+    ) -> None:
         super().__init__(relation, data_interface, component)
         self.unit = component
 
@@ -892,7 +891,7 @@ class UpgradeServerState(RelationState):
         )
 
     @unit_state.setter
-    def unit_state(self, value: UnitUpgradesState):
+    def unit_state(self, value: UnitUpgradesState) -> None:
         """Set the unit upgrade state in relation bag."""
         self.relation.data[self.unit].update({"state": value.value})
 
@@ -935,7 +934,7 @@ class ClusterState(Object, StatusesStateProtocol):
         s3_requirer: S3Requirer,
         azure_requires: AzureStorageRequires,
         gcs_requires: GcsStorageRequires,
-    ):
+    ) -> None:
         super().__init__(charm, "cluster_state")
         self.config = charm.config
         self.substrate = substrate

--- a/opensearch_single_kernel/core/state.py
+++ b/opensearch_single_kernel/core/state.py
@@ -9,9 +9,11 @@ import logging
 import os
 import re
 import socket
+import time
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any
 
+import poetry.core.constraints.version as poetry_version
 from data_platform_helpers.advanced_statuses import StatusesState, StatusObject
 from data_platform_helpers.advanced_statuses.protocol import StatusesStateProtocol
 from data_platform_helpers.advanced_statuses.types import Scope as AdvancedStatusesScope
@@ -38,6 +40,7 @@ from opensearch_single_kernel.common.constants import (
     SMTP_RELATION,
     STATUS_PEERS_RELATION,
     TLS_RELATION,
+    UPGRADE_RELATION,
     CertType,
     ObjectStorageType,
     Scope,
@@ -56,6 +59,8 @@ from opensearch_single_kernel.core.models import (
     PluginConfigInfo,
     ProductionProfile,
     TestingProfile,
+    UnitUpgradesState,
+    UpgradeVersions,
 )
 from opensearch_single_kernel.core.relations import (
     JwtData,
@@ -821,6 +826,104 @@ class LockServerState(RelationState):
         self.relation.data[self.unit].update({"-trigger": os.environ["JUJU_CONTEXT_ID"]})
 
 
+class UpgradeAppState(RelationState):
+    """State collection for the application side of upgrade relation."""
+
+    @property
+    def versions(self) -> UpgradeVersions | None:
+        """Get the versions of installed OpenSearch from the relation bag.
+
+        Should only be None during first charm install. If a user upgrades from a charm
+        that does not set versions, this charm will get stuck.
+        """
+        if not (raw := self.get_object("versions")):
+            return None
+        return UpgradeVersions.from_dict(raw)
+
+    @versions.setter
+    def versions(self, value: UpgradeVersions):
+        """Set the versions of installed OpenSearch in the relation bag.
+
+        Used after next upgrade to check compatibility (i.e. whether that upgrade should be
+        allowed).
+        """
+        self.put_object("versions", value.to_dict())
+
+    @property
+    def upgrade_resumed(self) -> bool:
+        """Get whether user has resumed upgrade with Juju action.
+
+        Reset to `False` after each `juju refresh`.
+        """
+        return self.relation_data.get("upgrade_resumed", "").lower() == "true"
+
+    @upgrade_resumed.setter
+    def upgrade_resumed(self, value: bool) -> None:
+        """Set whether user has resumed upgrade with Juju action."""
+        self.relation_data.update(
+            {
+                # Trigger peer relation_changed event even if value does not change
+                # (Needed when leader sets value to False during `ops.UpgradeCharmEvent`)
+                "-unused-timestamp-upgrade-resume-last-updated": str(time.time()),
+                "upgrade_resumed": str(value),
+            }
+        )
+
+
+class UpgradeServerState(RelationState):
+    """State collection for the unit side of upgrade relation."""
+
+    def __init__(
+        self,
+        relation: Relation | None,
+        data_interface: Data,
+        component: Unit,
+    ):
+        super().__init__(relation, data_interface, component)
+        self.unit = component
+
+    @property
+    def unit_state(self) -> UnitUpgradesState | None:
+        """Get the unit upgrade state from relation bag."""
+        return (
+            UnitUpgradesState(state)
+            if (state := self.relation.data[self.unit].get("state"))
+            else None
+        )
+
+    @unit_state.setter
+    def unit_state(self, value: UnitUpgradesState):
+        """Set the unit upgrade state in relation bag."""
+        self.relation.data[self.unit].update({"state": value.value})
+
+    @property
+    def snap_revision(self) -> str | None:
+        """Get the revision of installed OpenSearch snap from the relation bag."""
+        return self.relation.data[self.unit].get("snap_revision")
+
+    @snap_revision.setter
+    def snap_revision(self, value: str) -> None:
+        """Set the revision of installed OpenSearch snap in the relation bag."""
+        self.relation.data[self.unit].update({"snap_revision": value})
+
+    @property
+    def workload_version(self) -> str | None:
+        """Get the workload version of installed OpenSearch from the relation bag."""
+        return self.relation.data[self.unit].get("workload_version")
+
+    @workload_version.setter
+    def workload_version(self, value: str) -> None:
+        """Set the workload version of installed OpenSearch in the relation bag."""
+        self.relation.data[self.unit].update({"workload_version": value})
+
+    @property
+    def workload_version_parsed(self) -> poetry_version.Version | None:
+        """Get the parsed workload version of installed OpenSearch from the relation bag."""
+        return (
+            poetry_version.Version.parse(self.workload_version) if self.workload_version else None
+        )
+
+
 class ClusterState(Object, StatusesStateProtocol):
     """The global OpenSearch Cluster State ."""
 
@@ -914,6 +1017,11 @@ class ClusterState(Object, StatusesStateProtocol):
     def smtp_relations(self) -> list[Relation]:
         """Get SMTP relations."""
         return self.model.relations.get(SMTP_RELATION, [])
+
+    @property
+    def upgrade_relation(self) -> Relation | None:
+        """Get peer upgrade relation."""
+        return self.model.get_relation(UPGRADE_RELATION)
 
     @property
     def peer_cluster_orchestrator(self) -> PeerCluster:
@@ -1484,3 +1592,43 @@ class ClusterState(Object, StatusesStateProtocol):
                 raise OpenSearchInvalidStorageTypeError(
                     "Unsupported object storage type: %s" % object_storage_type
                 )
+
+    @property
+    def server_upgrade(self) -> UpgradeServerState:
+        """Get state of lock relation for current unit."""
+        return UpgradeServerState(
+            relation=self.upgrade_relation,
+            data_interface=DataPeerUnitData(model=self.model, relation_name=UPGRADE_RELATION),
+            component=self.model.unit,
+        )
+
+    @property
+    def application_upgrade(self) -> UpgradeAppState:
+        """Get application state of upgrade relation."""
+        return UpgradeAppState(
+            relation=self.upgrade_relation,
+            data_interface=DataPeerData(model=self.model, relation_name=UPGRADE_RELATION),
+            component=self.model.app,
+        )
+
+    @property
+    def sorted_server_upgrades(self) -> list[UpgradeServerState]:
+        """Get state of upgrade relation for all units in it sorted by highest unit number."""
+        return (
+            [
+                UpgradeServerState(
+                    relation=self.upgrade_relation,
+                    data_interface=DataPeerUnitData(
+                        model=self.model, relation_name=UPGRADE_RELATION
+                    ),
+                    component=unit,
+                )
+                for unit in sorted(
+                    (self.server.unit, *self.upgrade_relation.units),
+                    key=lambda unit: unit.name.split("/")[1],
+                    reverse=True,
+                )
+            ]
+            if self.upgrade_relation
+            else []
+        )

--- a/opensearch_single_kernel/events/custom_events.py
+++ b/opensearch_single_kernel/events/custom_events.py
@@ -7,7 +7,7 @@
 
 from typing import Any
 
-from ops import EventBase
+from ops import EventBase, Handle
 
 
 class StartOpenSearch(EventBase):
@@ -18,13 +18,13 @@ class StartOpenSearch(EventBase):
 
     def __init__(
         self,
-        handle,
+        handle: Handle,
         *,
         ignore_lock: bool = False,
         after_upgrade: bool = False,
         is_first_data_node: bool = False,
         override_version: bool = False,
-    ):
+    ) -> None:
         super().__init__(handle)
         self.ignore_lock = ignore_lock
         self.after_upgrade = after_upgrade
@@ -40,7 +40,7 @@ class StartOpenSearch(EventBase):
             "override_version": self.override_version,
         }
 
-    def restore(self, snapshot: dict[str, Any]):
+    def restore(self, snapshot: dict[str, Any]) -> None:
         """Restore data from Dict."""
         self.ignore_lock = snapshot["ignore_lock"]
         self.after_upgrade = snapshot["after_upgrade"]
@@ -62,7 +62,7 @@ class UpgradeOpenSearch(StartOpenSearch):
     `StartOpenSearch` will be emitted.
     """
 
-    def __init__(self, handle, *, ignore_lock=False):
+    def __init__(self, handle: Handle, *, ignore_lock: bool = False) -> None:
         super().__init__(handle, ignore_lock=ignore_lock)
 
 

--- a/opensearch_single_kernel/events/custom_events.py
+++ b/opensearch_single_kernel/events/custom_events.py
@@ -20,14 +20,16 @@ class StartOpenSearch(EventBase):
         self,
         handle,
         *,
-        ignore_lock=False,
-        after_upgrade=False,
-        is_first_data_node=False,
+        ignore_lock: bool = False,
+        after_upgrade: bool = False,
+        is_first_data_node: bool = False,
+        override_version: bool = False,
     ):
         super().__init__(handle)
         self.ignore_lock = ignore_lock
         self.after_upgrade = after_upgrade
         self.is_first_data_node = is_first_data_node
+        self.override_version = override_version
 
     def snapshot(self) -> dict[str, Any]:
         """Snapshot of the event data."""
@@ -35,6 +37,7 @@ class StartOpenSearch(EventBase):
             "ignore_lock": self.ignore_lock,
             "after_upgrade": self.after_upgrade,
             "is_first_data_node": self.is_first_data_node,
+            "override_version": self.override_version,
         }
 
     def restore(self, snapshot: dict[str, Any]):
@@ -42,6 +45,7 @@ class StartOpenSearch(EventBase):
         self.ignore_lock = snapshot["ignore_lock"]
         self.after_upgrade = snapshot["after_upgrade"]
         self.is_first_data_node = snapshot["is_first_data_node"]
+        self.override_version = snapshot["override_version"]
 
 
 class RestartOpenSearch(EventBase):
@@ -49,6 +53,17 @@ class RestartOpenSearch(EventBase):
 
     This event will be deferred until OpenSearch stops. Then, `_StartOpenSearch` will be emitted.
     """
+
+
+class UpgradeOpenSearch(StartOpenSearch):
+    """Attempt to acquire lock & upgrade OpenSearch.
+
+    This event will be deferred until OpenSearch stops. Then, the snap will be upgraded and
+    `StartOpenSearch` will be emitted.
+    """
+
+    def __init__(self, handle, *, ignore_lock=False):
+        super().__init__(handle, ignore_lock=ignore_lock)
 
 
 class ReloadKeystoreEvent(EventBase):

--- a/opensearch_single_kernel/events/external_clients.py
+++ b/opensearch_single_kernel/events/external_clients.py
@@ -192,6 +192,7 @@ class ExternalClientsEventsHandler(Object):
             return
         # remove departing unit from endpoints available to requirer charm.
         if event.departing_unit.app == self.charm.app:
+            self.charm.state.server.set_relation_departing(event.relation)
             departing_unit_ip = self.charm.state.unit_ip(event.departing_unit)
             self.update_external_client_endpoints(
                 external_client, omit_endpoints={departing_unit_ip}
@@ -226,9 +227,11 @@ class ExternalClientsEventsHandler(Object):
         """Handle client relation-broken event."""
         if not self.charm.unit.is_leader():
             return
-        external_client = self.charm.state.external_client_by_relation(event.relation)
-        if not external_client:
+        if not (external_client := self.charm.state.external_client_by_relation(event.relation)):
             logger.error("No external client found for relation id %d", event.relation.id)
+            return
+        if self.charm.state.server.get_relation_departing(event.relation):
+            self.charm.state.server.remove_relation_departing(event.relation)
             return
         if self.charm.upgrades_manager.in_progress:
             logger.warning(

--- a/opensearch_single_kernel/events/external_clients.py
+++ b/opensearch_single_kernel/events/external_clients.py
@@ -64,7 +64,13 @@ class ExternalClientsEventsHandler(Object):
             OpenSearchIndexError if the index name is invalid
             OpenSearchHttpError if we can't create the required index
         """
-        # TODO: If upgrade in progress then defer event
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Modifying relations during an upgrade is not supported."
+                "The charm may be in a broken, unrecoverable state"
+            )
+            event.defer()
+            return
 
         if not self.charm.unit.is_leader():
             return
@@ -224,12 +230,11 @@ class ExternalClientsEventsHandler(Object):
         if not external_client:
             logger.error("No external client found for relation id %d", event.relation.id)
             return
-        # TODO: Handle upgrades
-        # if self.charm.upgrade_in_progress:
-        #    logger.warning(
-        # "Modifying relations during an upgrade is not supported."
-        # "The charm may be in a broken, unrecoverable state"
-        # )
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Modifying relations during an upgrade is not supported."
+                "The charm may be in a broken, unrecoverable state"
+            )
         self.charm.external_clients_manager.remove_lingering_relation_users_and_roles(
             external_client
         )

--- a/opensearch_single_kernel/events/oauth.py
+++ b/opensearch_single_kernel/events/oauth.py
@@ -137,7 +137,7 @@ class OAuthEventsHandler(Object):
     def _on_oauth_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Handler for `relation_departed` event."""
         if event.departing_unit == self.charm.unit and self.charm.state.peer_relation is not None:
-            self.charm.state.server.oauth_departing = True
+            self.charm.state.server.set_relation_departing(event.relation)
 
     def _on_oauth_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handler for `relation_broken` event."""
@@ -153,7 +153,7 @@ class OAuthEventsHandler(Object):
             return
 
         if (
-            self.charm.state.server.oauth_departing
+            self.charm.state.server.get_relation_departing(event.relation)
             or not self.charm.state.application.is_security_index_initialised
         ):
             return

--- a/opensearch_single_kernel/events/opensearch.py
+++ b/opensearch_single_kernel/events/opensearch.py
@@ -62,7 +62,10 @@ from opensearch_single_kernel.common.statuses import (
     ProfileStatuses,
     TlsStatuses,
 )
-from opensearch_single_kernel.core.models import DeploymentDescription
+from opensearch_single_kernel.core.models import (
+    DeploymentDescription,
+    UnitUpgradesState,
+)
 from opensearch_single_kernel.events.custom_events import (
     RestartOpenSearch,
     StartOpenSearch,
@@ -126,21 +129,19 @@ class OpenSearchEventsHandler(Object):
 
     def _on_peer_relation_created(self, event: RelationCreatedEvent) -> None:
         """Event received by the new node joining the cluster."""
-        # TODO: Handle upgrades
-        # if self.upgrade_in_progress:
-        # logger.warning(
-        #    "Adding units during an upgrade is not supported. The charm may be in a broken,
-        #  unrecoverable state"
-        # )
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Adding units during an upgrade is not supported."
+                "The charm may be in a broken, unrecoverable state"
+            )
 
     def _on_peer_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Event received by all units when a new node joins the cluster."""
-        # TODO: Handle upgrades
-        # if self.upgrade_in_progress:
-        #    logger.warning(
-        #        "Adding units during an upgrade is not supported. The charm may be in a broken,
-        #  unrecoverable state"
-        #    )
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Adding units during an upgrade is not supported."
+                "The charm may be in a broken, unrecoverable state"
+            )
 
     def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:  # noqa: C901
         """Handle peer relation changes."""
@@ -194,6 +195,8 @@ class OpenSearchEventsHandler(Object):
             # self.peer_cluster_requirer.apply_orchestrator_status()
         elif event.relation.data.get(event.app):
             # if app_data + app_data["nodes_config"]: Reconfigure + restart node on the unit
+            if self.charm.upgrades_manager.in_progress:
+                return
             if self.charm.config_manager.update_opensearch_config():
                 logger.debug("Restarting opensearch due to reconfiguring node roles")
                 self.charm.restart_opensearch_event.emit()
@@ -213,12 +216,11 @@ class OpenSearchEventsHandler(Object):
 
     def _on_peer_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Relation departed event."""
-        # TODO: Handle upgrades
-        # if self.upgrade_in_progress:
-        #    logger.warning(
-        #        "Removing units during an upgrade is not supported. The charm may be in a broken,
-        #  unrecoverable state"
-        #    )
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Removing units during an upgrade is not supported."
+                "The charm may be in a broken, unrecoverable state"
+            )
         if not (deployment_desc := self.charm.state.application.deployment_desc):
             # that happens in the very last stages of the application removal
             return
@@ -259,7 +261,11 @@ class OpenSearchEventsHandler(Object):
 
     def _on_opensearch_data_storage_detaching(self, event: StorageDetachingEvent) -> None:
         """Triggered when removing unit, Prior to the storage being detached."""
-        # TODO: Warning in case of upgrade in progress
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Removing units during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
+            )
+
         planned_units = self.charm.app.planned_units()
 
         # acquire lock to ensure only 1 unit removed at a time
@@ -361,12 +367,10 @@ class OpenSearchEventsHandler(Object):
             self.charm.external_clients_manager.update_all_external_clients_relation_endpoints(
                 nodes
             )
-            # TODO: Handle upgrade in progress
-            # if self.upgrade_in_progress:
-            # logger.debug(
-            # "Skipping `remove_lingering_users_and_roles()` because upgrade is in-progress"
-            # )
-            if deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR:
+            if (
+                deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR
+                and not self.charm.upgrades_manager.in_progress
+            ):
                 self.charm.external_clients_manager.remove_lingering_relation_users_and_roles()
 
         # If the unit reloads its certs but the other units are not ready yet
@@ -438,7 +442,12 @@ class OpenSearchEventsHandler(Object):
             event.defer()
             return
 
-        # TODO: Handle upgrade in progress
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Changing config during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
+            )
+            event.defer()
+            return
 
         try:
             config_profile = self.charm.profiles_manager.config_profile
@@ -886,6 +895,14 @@ class OpenSearchEventsHandler(Object):
 
         self.charm.lock_manager.release()
 
+        if event.after_upgrade:
+            try:
+                self.charm.cluster_manager.opensearch_client.enable_shard_allocation()
+            except OpenSearchHttpError:
+                logger.exception("Failed to re-enable allocation after upgrade")
+                event.defer()
+                return
+
         # Add a timestamp to always trigger relation changed
         self.charm.state.server.started = str(time.time())
         self.charm.state.remove_status_if_present(
@@ -917,8 +934,53 @@ class OpenSearchEventsHandler(Object):
             self.charm.cluster_manager.name,
         )
 
-        # TODO: Handle event.after_upgrade
         # TODO: Handle refresh relation data of peer cluster
+        if event.after_upgrade:
+            health = self.charm.health_manager.get(local_app_only=False, wait_for_green_first=True)
+
+            # Cluster is considered healthy if green or yellow
+            # TODO future improvement: try to narrow scope to just green or green + yellow in
+            # specific cases
+            # https://github.com/canonical/opensearch-operator/issues/268
+            # See https://chat.canonical.com/canonical/pl/s5j64ekxwi8epq53kzhd8fhrco and
+            # https://chat.canonical.com/canonical/pl/zaizx3bu3j8ftfcw67qozw9dbo
+            # For now, we need to allow yellow because
+            # "During a rolling upgrade, primary shards assigned to a node running the new
+            # version cannot have their replicas assigned to a node with the old version. The new
+            # version might have a different data format that is not understood by the old
+            # version.
+            #
+            # "If it is not possible to assign the replica shards to another node (there is only
+            # one upgraded node in the cluster), the replica shards remain unassigned and status
+            # stays `yellow`.
+            #
+            # "In this case, you can proceed once there are no initializing or relocating shards
+            # (check the `init` and `relo` columns).
+            #
+            # "As soon as another node is upgraded, the replicas can be assigned and the status
+            # will change to `green`."
+            #
+            # from
+            # https://www.elastic.co/guide/en/elastic-stack/8.13/upgrading-elasticsearch.html#upgrading-elasticsearch
+            #
+            # If `health_ == HealthColors.YELLOW`, no shards are initializing or relocating
+            # (otherwise `health_` would be `HealthColors.YELLOW_TEMP`)
+            if health not in (HealthColors.GREEN, HealthColors.YELLOW):
+                logger.error("Cluster is not healthy after upgrade. Manual intervention required.")
+                event.defer()
+                return
+            elif health == HealthColors.YELLOW:
+                # TODO future improvement:
+                # https://github.com/canonical/opensearch-operator/issues/268
+                logger.warning(
+                    "Cluster is yellow. Upgrade may cause data loss if cluster is yellow for reason "
+                    "other than primary shards on upgraded unit & not enough upgraded units available "
+                    "for replica shards"
+                )
+
+        self.charm.state.server_upgrade.unit_state = UnitUpgradesState.HEALTHY
+        logger.debug("Set upgrade unit state to healthy")
+        self.charm.upgrade_events._reconcile_upgrade()
 
         self.post_start_ca_rotation()
 

--- a/opensearch_single_kernel/events/opensearch.py
+++ b/opensearch_single_kernel/events/opensearch.py
@@ -195,8 +195,6 @@ class OpenSearchEventsHandler(Object):
             # self.peer_cluster_requirer.apply_orchestrator_status()
         elif event.relation.data.get(event.app):
             # if app_data + app_data["nodes_config"]: Reconfigure + restart node on the unit
-            if self.charm.upgrades_manager.in_progress:
-                return
             if self.charm.config_manager.update_opensearch_config():
                 logger.debug("Restarting opensearch due to reconfiguring node roles")
                 self.charm.restart_opensearch_event.emit()
@@ -358,7 +356,11 @@ class OpenSearchEventsHandler(Object):
             if health == HealthColors.UNKNOWN:
                 return
 
-        if self.charm.unit.is_leader():
+        if self.charm.upgrades_manager.in_progress:
+            logger.debug(
+                "Skipping `remove_lingering_users_and_roles` and `update_all_external_clients_relation_endpoints` because upgrade is in-progress"
+            )
+        elif self.charm.unit.is_leader():
             try:
                 nodes = self.charm.cluster_manager.get_nodes(use_localhost=True)
             except OpenSearchHttpError as e:
@@ -367,10 +369,7 @@ class OpenSearchEventsHandler(Object):
             self.charm.external_clients_manager.update_all_external_clients_relation_endpoints(
                 nodes
             )
-            if (
-                deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR
-                and not self.charm.upgrades_manager.in_progress
-            ):
+            if deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR:
                 self.charm.external_clients_manager.remove_lingering_relation_users_and_roles()
 
         # If the unit reloads its certs but the other units are not ready yet

--- a/opensearch_single_kernel/events/snapshots.py
+++ b/opensearch_single_kernel/events/snapshots.py
@@ -528,9 +528,9 @@ class SnapshotsEventsHandler(Object):
 
         if not self.charm.state.application.deployment_desc:
             return "Deployment not ready."
-        # TODO: Handle upgrades
-        # if self.charm.upgrade_in_progress:
-        #    return "Backup/Restore operations not supported while upgrade in-progress."
+
+        if self.charm.upgrades_manager.in_progress:
+            return "Backup/Restore operations not supported while upgrade in-progress."
 
         if object_storage_type == ObjectStorageType.CONFLICT:
             return "Conflict: more than one object storage integrators integrated."

--- a/opensearch_single_kernel/events/tls.py
+++ b/opensearch_single_kernel/events/tls.py
@@ -78,7 +78,9 @@ class TLSEventsHandler(Object):
         if not self.charm.state.application.deployment_desc:
             event.fail("The action can only be run once the deployment is complete.")
             return
-        # TODO: Check if the charm is in upgrade
+        if self.charm.upgrades_manager.in_progress:
+            event.fail("Setting private key not supported while upgrade in-progress")
+            return
 
         if not self.charm.state.tls_relation:
             event.fail("TLS relation not available.")
@@ -111,7 +113,14 @@ class TLSEventsHandler(Object):
 
     def _on_tls_relation_created(self, event: RelationCreatedEvent) -> None:
         """Request certificate when TLS relation created."""
-        # TODO: Defer when upgrade is in progress
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Modifying relations during an upgrade is not supported."
+                "The charm may be in a broken, unrecoverable state"
+            )
+            event.defer()
+            return
+
         if not (deployment_desc := self.charm.state.application.deployment_desc):
             event.defer()
             return
@@ -163,7 +172,12 @@ class TLSEventsHandler(Object):
 
     def _on_tls_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Notify the charm that the relation is broken."""
-        # TODO: If upgrade log a warning
+        if self.charm.upgrades_manager.in_progress:
+            logger.warning(
+                "Modifying relations during an upgrade is not supported."
+                "The charm may be in a broken, unrecoverable state"
+            )
+
         if self.charm.tls_manager.all_tls_resources_stored():
             return
 
@@ -398,10 +412,9 @@ class TLSEventsHandler(Object):
         if not self.charm.unit.is_leader():
             event.fail("The action can only be run on leader unit.")
             return
-        # TODO: block on upgrade
-        # if self.upgrade_in_progress:
-        # event.fail("Setting password not supported while upgrade in-progress")
-        # return
+        if self.charm.upgrades_manager.in_progress:
+            event.fail("Setting password not supported while upgrade in-progress")
+            return
 
         user_name = event.params.get("username")
         if user_name not in OPENSEARCH_USERS:

--- a/opensearch_single_kernel/events/upgrades.py
+++ b/opensearch_single_kernel/events/upgrades.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for upgrade events."""
+
+import json
+import logging
+import typing
+
+import ops
+from data_platform_helpers.version_check import get_charm_revision
+from ops import Object
+
+from opensearch_single_kernel.common.constants import UPGRADE_RELATION, HealthColors
+from opensearch_single_kernel.common.exceptions import (
+    OpenSearchCmdError,
+    OpenSearchHttpError,
+    OpenSearchStopError,
+    OpenSearchUpgradePrecheckError,
+)
+from opensearch_single_kernel.common.statuses import UpgradesStatuses
+from opensearch_single_kernel.core.models import UnitUpgradesState
+from opensearch_single_kernel.events.custom_events import UpgradeOpenSearch
+
+if typing.TYPE_CHECKING:
+    from opensearch_single_kernel.charms.base import OpenSearchBaseCharm
+
+logger = logging.getLogger(__name__)
+
+
+class UpgradesEventsHandler(Object):
+    """Class implementing OpenSearch upgrades event handling."""
+
+    def __init__(self, charm: "OpenSearchBaseCharm"):
+        super().__init__(charm, key="upgrade_events")
+        self.charm = charm
+
+        self.framework.observe(self.charm.on.upgrade_charm, self._on_upgrade_charm)
+        self.framework.observe(
+            self.charm.on[UPGRADE_RELATION].relation_created,
+            self._on_upgrade_peer_relation_created,
+        )
+        self.framework.observe(
+            self.charm.on[UPGRADE_RELATION].relation_changed, self._reconcile_upgrade
+        )
+        self.framework.observe(
+            self.charm.on.pre_upgrade_check_action, self._on_pre_upgrade_check_action
+        )
+        self.framework.observe(self.charm.on.resume_upgrade_action, self._on_resume_upgrade_action)
+        self.framework.observe(self.charm.on.force_upgrade_action, self._on_force_upgrade_action)
+        self.framework.observe(self.charm.upgrade_opensearch_event, self._upgrade_opensearch)
+        self.framework.observe(
+            self.charm.on.force_refresh_start_action,
+            self._on_refresh_force_start_action,
+        )
+
+    def _on_upgrade_peer_relation_created(self, _) -> None:
+        """Handle relation created events."""
+        self.charm.upgrades_manager.save_snap_revision_after_first_install()
+        if self.charm.unit.is_leader():
+            if not self.charm.upgrades_manager.in_progress:
+                # Save versions on initial start
+                logger.debug(
+                    f"Setting {self.charm.upgrades_manager.current_versions=} in upgrade peer relation app databag"
+                )
+                self.charm.state.application_upgrade.versions = (
+                    self.charm.upgrades_manager.current_versions
+                )
+
+    def _reconcile_upgrade(self, _=None):  # noqa: C901
+        """Handle upgrade events."""
+        if not self.charm.state.upgrade_relation:
+            logger.debug("Peer relation not available")
+            return
+        if not self.charm.state.application_upgrade.versions:
+            logger.debug("Peer relation not ready")
+            return
+        if self.charm.unit.is_leader() and not self.charm.upgrades_manager.in_progress:
+            # Run before checking `self._upgrade.is_compatible` in case incompatible upgrade was
+            # forced & completed on all units.
+            # Side effect: on machines, if charm was upgraded to a charm with the same snap
+            # revision, compatibility checks will be skipped.
+            # (The only real use case for this would be upgrading the charm code to an incompatible
+            # version without upgrading the snap. In that situation, the upgrade may appear
+            # successful and the user will not be notified of the charm incompatibility. This case
+            # is much less likely than the forced incompatible upgrade & the impact is not as bad
+            # as the impact if we did not handle the forced incompatible upgrade case.)
+            logger.debug(
+                f"Setting {self.charm.upgrades_manager.current_versions=} in upgrade peer relation app databag"
+            )
+            self.charm.state.application_upgrade.versions = (
+                self.charm.upgrades_manager.current_versions
+            )
+        if not self.charm.upgrades_manager.is_compatible:
+            self._set_upgrade_status()
+            return
+
+        # CHECK FOR ROLLBACK
+        if (
+            self.charm.upgrades_manager.is_rollback
+            and not self.charm.upgrades_manager.can_rollback
+        ):
+            logger.error(
+                "Rollback unsupported. Refresh to a newer revision or consult the recovery documentation"
+            )
+            self._set_upgrade_status()
+            # TODO: LOG LINK TO RECOVERY DOCS
+            return
+
+        if self.charm.upgrades_manager.unit_state is UnitUpgradesState.OUTDATED:
+            logger.debug(
+                f"Rollback status: is_rollback={self.charm.upgrades_manager.is_rollback}, can_rollback={self.charm.upgrades_manager.can_rollback}"
+            )
+            if self.charm.upgrades_manager.is_rollback:
+                logger.warning("Rollback detected")
+                logger.warning(
+                    "Rollback incompatible. Run 'juju run <unit> force-refresh-start' with `check-compatibility` set to false to override node version and attempt startup procedure"
+                )
+                self._set_upgrade_status()
+                self.charm.lock_manager.release()
+                return
+            try:
+                if self.charm.upgrades_manager.requires_general_prechecks:
+                    self._run_general_prechecks()
+                authorized = self.charm.upgrades_manager.authorized
+            except OpenSearchUpgradePrecheckError as exception:
+                self.charm.state.add_status_if_not_present(
+                    UpgradesStatuses.UPGRADES_PRE_UPGRADE_CHECK_FAILED.value,
+                    "unit",
+                    self.charm.upgrades_manager.name,
+                )
+                logger.error(exception)
+                return
+            if authorized:
+                self._set_upgrade_status()
+                self.charm.upgrade_opensearch_event.emit()
+            else:
+                logger.debug("Waiting to upgrade")
+        self._set_upgrade_status()
+
+    def _run_general_prechecks(self) -> None:
+        """Check health and snapshot state before upgrade.
+
+        Raises:
+            PrecheckFailed: If cluster is not ready to upgrade.
+        """
+        health = self.charm.health_manager.get(local_app_only=False, wait_for_green_first=True)
+        if health != HealthColors.GREEN:
+            raise OpenSearchUpgradePrecheckError(f"Cluster health is {health} instead of green")
+        if self.charm.snapshots_manager.is_operation_in_progress:
+            raise OpenSearchUpgradePrecheckError("Backup or restore is in progress")
+
+    def _set_upgrade_status(self):
+        """Set upgrade unit status while clearing all other upgrade statuses."""
+        unit_status, unit_dynamic_params = self.charm.upgrades_manager.unit_status
+        app_status = self.charm.upgrades_manager.app_status
+
+        for status in UpgradesStatuses:
+            if status is not unit_status:
+                self.charm.state.remove_status_if_present(
+                    status.value, "unit", self.charm.upgrades_manager.name, interpolated=True
+                )
+            if status is not app_status:
+                self.charm.state.remove_status_if_present(
+                    status.value, "app", self.charm.upgrades_manager.name
+                )
+
+        if unit_status:
+            self.charm.state.add_status_if_not_present(
+                unit_status,
+                "unit",
+                self.charm.upgrades_manager.name,
+                dynamic_params=unit_dynamic_params,
+            )
+        if app_status:
+            self.charm.state.add_status_if_not_present(
+                app_status,
+                "app",
+                self.charm.upgrades_manager.name,
+            )
+
+    def _on_upgrade_charm(self, _):
+        """Handle Juju upgrade charm event."""
+        self.update_grafana_dashboards_title()
+        # TODO check backwards compatibility for profiles
+
+        if self.charm.unit.is_leader():
+            if not self.charm.upgrades_manager.in_progress:
+                logger.info("Charm upgraded. OpenSearch version unchanged")
+            self.charm.state.application_upgrade.upgrade_resumed = False
+            # Only call `_reconcile_upgrade` on leader unit to avoid race conditions with
+            # `upgrade_resumed`
+            self._reconcile_upgrade()
+
+    def _on_pre_upgrade_check_action(self, event: ops.ActionEvent) -> None:
+        """Handle pre-upgrade-check action."""
+        if not self.charm.unit.is_leader():
+            message = f"Must run action on leader unit. (e.g. `juju run {self.charm.app.name}/leader pre-upgrade-check`)"
+            logger.debug(f"Pre-upgrade check event failed: {message}")
+            event.fail(message)
+            return
+        if not self.charm.state.upgrade_relation or self.charm.upgrades_manager.in_progress:
+            message = "Upgrade already in progress"
+            logger.debug(f"Pre-upgrade check event failed: {message}")
+            event.fail(message)
+            return
+        try:
+            self._run_general_prechecks()
+            self.charm.upgrades_manager.pre_upgrade_check()
+        except OpenSearchUpgradePrecheckError as exception:
+            message = f"Charm is *not* ready for upgrade. Pre-upgrade check failed: {exception}"
+            logger.debug(f"Pre-upgrade check event failed: {message}")
+            event.fail(message)
+            return
+        message = "Charm is ready for upgrade"
+        event.set_results({"result": message})
+        logger.debug(f"Pre-upgrade check event succeeded: {message}")
+
+    def _on_resume_upgrade_action(self, event: ops.ActionEvent) -> None:
+        """Handle resume-upgrade action."""
+        if not self.charm.unit.is_leader():
+            message = f"Must run action on leader unit. (e.g. `juju run {self.charm.app.name}/leader resume-upgrade`)"
+            logger.debug(f"Resume upgrade event failed: {message}")
+            event.fail(message)
+            return
+        if not self.charm.state.upgrade_relation or not self.charm.upgrades_manager.in_progress:
+            message = "No upgrade in progress"
+            logger.debug(f"Resume upgrade event failed: {message}")
+            event.fail(message)
+            return
+        self.charm.upgrades_manager.reconcile_partition(action_event=event)
+        # If next to upgrade, upgrade leader unit
+        self._reconcile_upgrade()
+
+    def _on_force_upgrade_action(self, event: ops.ActionEvent) -> None:
+        """Handle force-upgrade action."""
+        if not self.charm.state.upgrade_relation or not self.charm.upgrades_manager.in_progress:
+            message = "No upgrade in progress"
+            logger.debug(f"Force upgrade event failed: {message}")
+            event.fail(message)
+            return
+        if not self.charm.state.application_upgrade.upgrade_resumed:
+            message = f"Run `juju run {self.charm.app.name}/leader resume-upgrade` before trying to force upgrade"
+            logger.debug(f"Force upgrade event failed: {message}")
+            event.fail(message)
+            return
+        if self.charm.upgrades_manager.unit_state is not UnitUpgradesState.OUTDATED:
+            message = "Unit already upgraded"
+            logger.debug(f"Force upgrade event failed: {message}")
+            event.fail(message)
+            return
+        logger.debug("Forcing upgrade")
+        event.log(f"Forcefully upgrading {self.charm.unit.name}")
+        # TODO: replace `ignore_lock=False` with `event.params["ignore-lock"]` if specification
+        # DA091 approved
+        # (https://docs.google.com/document/d/1rwnS-deJU9Mzc8BFkl3UGgjZiBa6e3bxoT-6BQo9e3E/edit)
+        self.charm.upgrade_opensearch_event.emit(ignore_lock=False)
+        event.set_results({"result": f"Forcefully upgraded {self.charm.unit.name}"})
+        logger.debug("Forced upgrade")
+
+    def _upgrade_opensearch(self, event: UpgradeOpenSearch) -> None:  # noqa: C901
+        """Handle upgrade OpenSearch event."""
+        logger.debug("Attempting to acquire lock for upgrade")
+        if not self.charm.lock_manager.acquire():
+            # (Attempt to acquire lock even if `event.ignore_lock`)
+            if event.ignore_lock:
+                logger.debug("Upgrading without lock")
+            else:
+                logger.debug("Lock to upgrade opensearch not acquired. Will retry next event")
+                event.defer()
+                return
+        logger.debug("Acquired lock for upgrade")
+
+        # https://www.elastic.co/guide/en/elastic-stack/8.13/upgrading-elasticsearch.html
+        try:
+            self.charm.cluster_manager.opensearch_client.disable_shard_allocation()
+        except OpenSearchHttpError:
+            logger.exception("Failed to disable shard allocation before upgrade")
+            self.charm.lock_manager.release()
+            event.defer()
+            return
+        try:
+            self.charm.cluster_manager.opensearch_client.flush()
+        except OpenSearchHttpError as e:
+            logger.debug("Failed to flush before upgrade", exc_info=e)
+
+        logger.debug("Stopping OpenSearch before upgrade")
+        try:
+            self.charm.stop_opensearch(restart=True)
+        except OpenSearchStopError as e:
+            logger.exception(e)
+            self.charm.lock_manager.release()
+            event.defer()
+            return
+        logger.debug("Stopped OpenSearch before upgrade")
+
+        self.charm.upgrades_manager.upgrade_unit(snap=self.charm.workload)
+
+        if event.override_version:
+            logger.debug("Overriding OpenSearch version")
+            try:
+                self.charm.upgrades_manager.override_version()
+            except OpenSearchCmdError as e:
+                logger.error("Failed to override OpenSearch version: %s", str(e))
+
+        logger.debug("Starting OpenSearch after upgrade")
+        self.charm.start_opensearch_event.emit(ignore_lock=event.ignore_lock, after_upgrade=True)
+
+    def _on_refresh_force_start_action(self, event: ops.ActionEvent) -> None:
+        """Handle force-refresh-start action for rollback scenario."""
+        if not self.charm.upgrades_manager.is_rollback:
+            logger.debug("For refresh start event failed: No rollback in progress")
+            event.fail("No rollback in progress")
+            return
+        if self.charm.upgrades_manager.unit_state is not UnitUpgradesState.OUTDATED:
+            message = "Unit already upgraded"
+            logger.debug(f"Force upgrade event failed: {message}")
+            event.fail(message)
+            return
+        if event.params.get("check-compatibility", True):
+            message = "Rollbacks are not supported. This action will attempt to start the unit with the current version of OpenSearch. If the current version is incompatible with the cluster, the unit may fail to start. Rerun with `check-compatibility` set to false to override this check and attempt startup procedure."
+            logger.debug("Refresh force start event failed: %s", message)
+            event.fail(message)
+            return
+        self.charm.upgrade_opensearch_event.emit(override_version=True)
+        event.set_results(
+            {"result": f"Overrode OpenSearch version on {self.charm.state.unit_name}"}
+        )
+        logger.debug("Overrode OpenSearch version")
+
+    def update_grafana_dashboards_title(self) -> None:
+        """Update the title of the Grafana dashboard file to include the charm revision."""
+        revision = get_charm_revision(self.charm.model.unit)
+
+        dashboard = json.loads(
+            self.charm.workload.read_text(self.charm.workload.paths.grafana_dashboard)
+        )
+
+        old_title = dashboard.get("title", "Charmed OpenSearch")
+        title_prefix = old_title.split(" - Rev")[0]
+        new_title = f"{old_title} - Rev {revision}"
+        dashboard["title"] = f"{title_prefix} - Rev {revision}"
+
+        logger.info(
+            "Changing the title of grafana dashboard from %s to %s",
+            old_title,
+            new_title,
+        )
+
+        self.charm.workload.write_text(
+            json.dumps(dashboard, indent=4), self.charm.workload.paths.grafana_dashboard
+        )

--- a/opensearch_single_kernel/events/upgrades.py
+++ b/opensearch_single_kernel/events/upgrades.py
@@ -4,7 +4,6 @@
 
 """Handler for upgrade events."""
 
-import json
 import logging
 import typing
 
@@ -20,7 +19,10 @@ from opensearch_single_kernel.common.exceptions import (
     OpenSearchUpgradePrecheckError,
 )
 from opensearch_single_kernel.common.statuses import UpgradesStatuses
-from opensearch_single_kernel.core.models import UnitUpgradesState
+from opensearch_single_kernel.core.models import (
+    LifecycleUnitTearingDownAndAppActive,
+    UnitUpgradesState,
+)
 from opensearch_single_kernel.events.custom_events import UpgradeOpenSearch
 
 if typing.TYPE_CHECKING:
@@ -32,9 +34,18 @@ logger = logging.getLogger(__name__)
 class UpgradesEventsHandler(Object):
     """Class implementing OpenSearch upgrades event handling."""
 
-    def __init__(self, charm: "OpenSearchBaseCharm"):
+    lifecycle_state_stored = ops.StoredState()
+
+    def __init__(self, charm: "OpenSearchBaseCharm") -> None:
         super().__init__(charm, key="upgrade_events")
         self.charm = charm
+
+        # lifecycle
+        for relation_endpoint in self.model.relations.keys():
+            self.framework.observe(
+                self.charm.on[relation_endpoint].relation_departed,
+                self._on_lifecycle_relation_departed,
+            )
 
         self.framework.observe(self.charm.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(
@@ -58,25 +69,39 @@ class UpgradesEventsHandler(Object):
     def _on_upgrade_peer_relation_created(self, _) -> None:
         """Handle relation created events."""
         self.charm.upgrades_manager.save_snap_revision_after_first_install()
-        if self.charm.unit.is_leader():
-            if not self.charm.upgrades_manager.in_progress:
-                # Save versions on initial start
-                logger.debug(
-                    f"Setting {self.charm.upgrades_manager.current_versions=} in upgrade peer relation app databag"
-                )
-                self.charm.state.application_upgrade.versions = (
-                    self.charm.upgrades_manager.current_versions
-                )
+
+        if not self.authorized_leader:
+            logger.debug("Skipping upgrade relation created because unit is not leader")
+            return
+
+        if self.charm.upgrades_manager.in_progress:
+            logger.debug("Skipping upgrade relation created because upgrade in progress")
+            return
+
+        # Save versions on initial start
+        logger.debug(
+            "Setting %r in upgrade peer relation app databag",
+            self.charm.upgrades_manager.current_versions,
+        )
+        self.charm.state.application_upgrade.versions = (
+            self.charm.upgrades_manager.current_versions
+        )
+        logger.debug(
+            "Set %r in upgrade peer relation app databag",
+            self.charm.upgrades_manager.current_versions,
+        )
 
     def _reconcile_upgrade(self, _=None):  # noqa: C901
         """Handle upgrade events."""
         if not self.charm.state.upgrade_relation:
             logger.debug("Peer relation not available")
             return
+
         if not self.charm.state.application_upgrade.versions:
             logger.debug("Peer relation not ready")
             return
-        if self.charm.unit.is_leader() and not self.charm.upgrades_manager.in_progress:
+
+        if self.authorized_leader and not self.charm.upgrades_manager.in_progress:
             # Run before checking `self._upgrade.is_compatible` in case incompatible upgrade was
             # forced & completed on all units.
             # Side effect: on machines, if charm was upgraded to a charm with the same snap
@@ -87,10 +112,15 @@ class UpgradesEventsHandler(Object):
             # is much less likely than the forced incompatible upgrade & the impact is not as bad
             # as the impact if we did not handle the forced incompatible upgrade case.)
             logger.debug(
-                f"Setting {self.charm.upgrades_manager.current_versions=} in upgrade peer relation app databag"
+                "Setting %r in upgrade peer relation app databag",
+                self.charm.upgrades_manager.current_versions,
             )
             self.charm.state.application_upgrade.versions = (
                 self.charm.upgrades_manager.current_versions
+            )
+            logger.debug(
+                "Set %r in upgrade peer relation app databag",
+                self.charm.upgrades_manager.current_versions,
             )
         if not self.charm.upgrades_manager.is_compatible:
             self._set_upgrade_status()
@@ -105,7 +135,7 @@ class UpgradesEventsHandler(Object):
                 "Rollback unsupported. Refresh to a newer revision or consult the recovery documentation"
             )
             self._set_upgrade_status()
-            # TODO: LOG LINK TO RECOVERY DOCS
+            # https://canonical-charmed-opensearch.readthedocs-hosted.com/2/how-to/upgrade/#recovering-from-a-rollback
             return
 
         if self.charm.upgrades_manager.unit_state is UnitUpgradesState.OUTDATED:
@@ -182,29 +212,36 @@ class UpgradesEventsHandler(Object):
 
     def _on_upgrade_charm(self, _):
         """Handle Juju upgrade charm event."""
-        self.update_grafana_dashboards_title()
+        self.charm.upgrades_manager.update_grafana_dashboards_title(
+            get_charm_revision(self.charm.model.unit)
+        )
         # TODO check backwards compatibility for profiles
 
-        if self.charm.unit.is_leader():
-            if not self.charm.upgrades_manager.in_progress:
-                logger.info("Charm upgraded. OpenSearch version unchanged")
-            self.charm.state.application_upgrade.upgrade_resumed = False
-            # Only call `_reconcile_upgrade` on leader unit to avoid race conditions with
-            # `upgrade_resumed`
-            self._reconcile_upgrade()
+        if not self.authorized_leader:
+            return
+
+        if not self.charm.upgrades_manager.in_progress:
+            logger.info("Charm upgraded. OpenSearch version unchanged")
+
+        self.charm.state.application_upgrade.upgrade_resumed = False
+        # Only call `_reconcile_upgrade` on leader unit to avoid race conditions with
+        # `upgrade_resumed`
+        self._reconcile_upgrade()
 
     def _on_pre_upgrade_check_action(self, event: ops.ActionEvent) -> None:
         """Handle pre-upgrade-check action."""
-        if not self.charm.unit.is_leader():
+        if not self.authorized_leader:
             message = f"Must run action on leader unit. (e.g. `juju run {self.charm.app.name}/leader pre-upgrade-check`)"
             logger.debug(f"Pre-upgrade check event failed: {message}")
             event.fail(message)
             return
+
         if not self.charm.state.upgrade_relation or self.charm.upgrades_manager.in_progress:
             message = "Upgrade already in progress"
             logger.debug(f"Pre-upgrade check event failed: {message}")
             event.fail(message)
             return
+
         try:
             self._run_general_prechecks()
             self.charm.upgrades_manager.pre_upgrade_check()
@@ -219,16 +256,18 @@ class UpgradesEventsHandler(Object):
 
     def _on_resume_upgrade_action(self, event: ops.ActionEvent) -> None:
         """Handle resume-upgrade action."""
-        if not self.charm.unit.is_leader():
+        if not self.authorized_leader:
             message = f"Must run action on leader unit. (e.g. `juju run {self.charm.app.name}/leader resume-upgrade`)"
             logger.debug(f"Resume upgrade event failed: {message}")
             event.fail(message)
             return
+
         if not self.charm.state.upgrade_relation or not self.charm.upgrades_manager.in_progress:
             message = "No upgrade in progress"
             logger.debug(f"Resume upgrade event failed: {message}")
             event.fail(message)
             return
+
         self.charm.upgrades_manager.reconcile_partition(action_event=event)
         # If next to upgrade, upgrade leader unit
         self._reconcile_upgrade()
@@ -240,16 +279,19 @@ class UpgradesEventsHandler(Object):
             logger.debug(f"Force upgrade event failed: {message}")
             event.fail(message)
             return
+
         if not self.charm.state.application_upgrade.upgrade_resumed:
             message = f"Run `juju run {self.charm.app.name}/leader resume-upgrade` before trying to force upgrade"
             logger.debug(f"Force upgrade event failed: {message}")
             event.fail(message)
             return
+
         if self.charm.upgrades_manager.unit_state is not UnitUpgradesState.OUTDATED:
             message = "Unit already upgraded"
             logger.debug(f"Force upgrade event failed: {message}")
             event.fail(message)
             return
+
         logger.debug("Forcing upgrade")
         event.log(f"Forcefully upgrading {self.charm.unit.name}")
         # TODO: replace `ignore_lock=False` with `event.params["ignore-lock"]` if specification
@@ -281,7 +323,7 @@ class UpgradesEventsHandler(Object):
             event.defer()
             return
         try:
-            self.charm.cluster_manager.opensearch_client.flush()
+            self.charm.cluster_manager.opensearch_client.flush_translog()
         except OpenSearchHttpError as e:
             logger.debug("Failed to flush before upgrade", exc_info=e)
 
@@ -313,41 +355,80 @@ class UpgradesEventsHandler(Object):
             logger.debug("For refresh start event failed: No rollback in progress")
             event.fail("No rollback in progress")
             return
+
         if self.charm.upgrades_manager.unit_state is not UnitUpgradesState.OUTDATED:
             message = "Unit already upgraded"
             logger.debug(f"Force upgrade event failed: {message}")
             event.fail(message)
             return
+
         if event.params.get("check-compatibility", True):
             message = "Rollbacks are not supported. This action will attempt to start the unit with the current version of OpenSearch. If the current version is incompatible with the cluster, the unit may fail to start. Rerun with `check-compatibility` set to false to override this check and attempt startup procedure."
             logger.debug("Refresh force start event failed: %s", message)
             event.fail(message)
             return
+
         self.charm.upgrade_opensearch_event.emit(override_version=True)
         event.set_results(
             {"result": f"Overrode OpenSearch version on {self.charm.state.unit_name}"}
         )
         logger.debug("Overrode OpenSearch version")
 
-    def update_grafana_dashboards_title(self) -> None:
-        """Update the title of the Grafana dashboard file to include the charm revision."""
-        revision = get_charm_revision(self.charm.model.unit)
+    # Lifecycle
 
-        dashboard = json.loads(
-            self.charm.workload.read_text(self.charm.workload.paths.grafana_dashboard)
+    def _on_lifecycle_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
+        """Handle relation departed event for lifecycle tracking."""
+        if event.departing_unit == self.charm.unit:
+            self._unit_tearing_down_and_app_active = LifecycleUnitTearingDownAndAppActive.TRUE
+
+    @property
+    def _unit_tearing_down_and_app_active(self) -> LifecycleUnitTearingDownAndAppActive:
+        """Whether unit is tearing down and 1+ other units are NOT tearing down."""
+        try:
+            return LifecycleUnitTearingDownAndAppActive(
+                self.lifecycle_state_stored.unit_tearing_down_and_app_active
+            )
+        except AttributeError:
+            return LifecycleUnitTearingDownAndAppActive.FALSE
+
+    @_unit_tearing_down_and_app_active.setter
+    def _unit_tearing_down_and_app_active(
+        self, enum_member: LifecycleUnitTearingDownAndAppActive
+    ) -> None:
+        """Set whether unit is tearing down and 1+ other units are NOT tearing down."""
+        self.lifecycle_state_stored.unit_tearing_down_and_app_active = enum_member.value
+
+    @property
+    def tearing_down_and_app_active(self) -> bool:
+        """Whether unit is tearing down and 1+ other units are NOT tearing down
+
+        Cannot be called on subordinate charms
+        """
+        return (
+            self._unit_tearing_down_and_app_active
+            is not LifecycleUnitTearingDownAndAppActive.FALSE
         )
 
-        old_title = dashboard.get("title", "Charmed OpenSearch")
-        title_prefix = old_title.split(" - Rev")[0]
-        new_title = f"{old_title} - Rev {revision}"
-        dashboard["title"] = f"{title_prefix} - Rev {revision}"
+    @property
+    def authorized_leader(self) -> bool:
+        """Whether unit is authorized to act as leader
 
-        logger.info(
-            "Changing the title of grafana dashboard from %s to %s",
-            old_title,
-            new_title,
-        )
+        Returns `False` if unit is tearing down and will be replaced by another leader
 
-        self.charm.workload.write_text(
-            json.dumps(dashboard, indent=4), self.charm.workload.paths.grafana_dashboard
-        )
+        For subordinate charms, this should not be accessed during *-relation-departed.
+
+        Teardown event sequence:
+        *-relation-departed -> *-relation-broken
+        stop
+        remove
+
+        Workaround for https://bugs.launchpad.net/juju/+bug/1979811
+        (Unit receives *-relation-broken event when relation still exists [for other units])
+        """
+        if not self.charm.unit.is_leader():
+            return False
+        if self._unit_tearing_down_and_app_active is LifecycleUnitTearingDownAndAppActive.UNKNOWN:
+            logger.warning(
+                f"{type(self)}.authorized_leader should not be accessed during *-relation-departed for subordinate relations"
+            )
+        return self._unit_tearing_down_and_app_active is LifecycleUnitTearingDownAndAppActive.FALSE

--- a/opensearch_single_kernel/managers/lock.py
+++ b/opensearch_single_kernel/managers/lock.py
@@ -31,7 +31,7 @@ from opensearch_single_kernel.common.exceptions import (
     OpenSearchLockError,
 )
 from opensearch_single_kernel.common.statuses import LockStatuses
-from opensearch_single_kernel.core.models import DeploymentDescription, PeerClusterApp
+from opensearch_single_kernel.core.models import DeploymentDescription
 from opensearch_single_kernel.core.state import ClusterState
 from opensearch_single_kernel.managers.base import BaseManager
 from opensearch_single_kernel.utils.helpers import format_unit_name
@@ -297,8 +297,7 @@ class LockManager(PeerLockManager):
             # handle case of large deployments
             other_apps_units = []
             if all_apps := self.state.application.cluster_fleet_apps:
-                for app in all_apps.values():
-                    p_cluster_app = PeerClusterApp.from_dict(app)
+                for p_cluster_app in all_apps.values():
                     if p_cluster_app.app.id == current_app.id:
                         continue
 

--- a/opensearch_single_kernel/managers/upgrades_base.py
+++ b/opensearch_single_kernel/managers/upgrades_base.py
@@ -184,11 +184,6 @@ class UpgradesManagerBase(BaseManager):
         self, scope: AdvancedStatusesScope, recompute: bool = False
     ) -> list[StatusObject]:
         """Compute the manager's statuses."""
-        if not recompute:
-            return self.state.statuses.get(scope, self.name).root or [
-                GeneralStatuses.ACTIVE_IDLE.value
-            ]
-
         unit_status, unit_dynamic_params = self.unit_status
         if scope == "unit" and unit_status:
             return [format_status(unit_status, unit_dynamic_params)]
@@ -272,3 +267,22 @@ class UpgradesManagerBase(BaseManager):
 
         logger.warning("Rollback not supported from %s to %s", unit_bag_version, version_on_disk)
         return False
+
+    def update_grafana_dashboards_title(self, charm_revision: str) -> None:
+        """Update the title of the Grafana dashboard file to include the charm revision."""
+        dashboard = json.loads(self.workload.read_text(self.workload.paths.grafana_dashboard))
+
+        old_title = dashboard.get("title", "Charmed OpenSearch")
+        title_prefix = old_title.split(" - Rev")[0]
+        new_title = f"{old_title} - Rev {charm_revision}"
+        dashboard["title"] = f"{title_prefix} - Rev {charm_revision}"
+
+        logger.info(
+            "Changing the title of grafana dashboard from %s to %s",
+            old_title,
+            new_title,
+        )
+
+        self.workload.write_text(
+            json.dumps(dashboard, indent=4), self.workload.paths.grafana_dashboard
+        )

--- a/opensearch_single_kernel/managers/upgrades_base.py
+++ b/opensearch_single_kernel/managers/upgrades_base.py
@@ -1,0 +1,274 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""In-place upgrades
+
+Based off specification: DA058 - In-Place Upgrades - Kubernetes v2
+(https://docs.google.com/document/d/1tLjknwHudjcHs42nzPVBNkHs98XxAOT2BXGGpP7NyEU/)
+"""
+
+import abc
+import json
+import logging
+from typing import Any
+
+import ops
+from data_platform_helpers.advanced_statuses import StatusObject
+from data_platform_helpers.advanced_statuses.types import Scope as AdvancedStatusesScope
+from overrides import override
+
+from opensearch_single_kernel.common.constants import UPGRADES_COMPATIBILITY_MATRIX
+from opensearch_single_kernel.common.exceptions import (
+    OpenSearchFileOperationError,
+    OpenSearchHttpError,
+    OpenSearchUpgradePrecheckError,
+)
+from opensearch_single_kernel.common.statuses import GeneralStatuses, UpgradesStatuses
+from opensearch_single_kernel.core.models import UpgradeVersions
+from opensearch_single_kernel.core.state import ClusterState
+from opensearch_single_kernel.managers.base import BaseManager
+from opensearch_single_kernel.utils.status import format_status
+from opensearch_single_kernel.workload.base import BaseWorkload
+
+logger = logging.getLogger(__name__)
+
+
+class UpgradesManagerBase(BaseManager):
+    """In-place upgrades"""
+
+    def __init__(
+        self,
+        state: ClusterState,
+        workload: BaseWorkload,
+    ) -> None:
+        super().__init__(state, workload, "upgrades_manager")
+        self.reconcile_compatibility_matrix()
+
+    @property
+    def current_versions(self) -> UpgradeVersions:
+        """Get the intended versions of OpenSearch by current charm."""
+        return UpgradeVersions(
+            charm=self.workload.paths.charm_version.read_text().strip(),
+            workload=self.workload.paths.workload_version.read_text().strip(),
+        )
+
+    @property
+    def is_compatible(self) -> bool:
+        """Whether upgrade is supported from previous versions"""
+        assert (previous_versions := self.state.application_upgrade.versions)
+
+        try:
+            if (
+                previous_versions.charm_parsed > self.current_versions.charm_parsed
+                or previous_versions.charm_parsed.major != self.current_versions.charm_parsed.major
+            ):
+                logger.debug(
+                    f"{previous_versions.charm_parsed=} incompatible with {self.current_versions.charm_parsed=}"
+                )
+                return False
+            if (
+                previous_versions.workload_parsed > self.current_versions.workload_parsed
+                or previous_versions.workload_parsed.major
+                != self.current_versions.workload_parsed.major
+            ):
+                logger.debug(
+                    f"{previous_versions.workload_parsed=} incompatible with {self.current_versions.workload_parsed=}"
+                )
+                return False
+            logger.debug(
+                f"Versions before upgrade compatible with versions after upgrade {previous_versions=} {self.current_versions=}"
+            )
+            return True
+        except KeyError as exception:
+            logger.debug(f"Version missing from {previous_versions=}", exc_info=exception)
+            return False
+
+    @property
+    @abc.abstractmethod
+    def in_progress(self) -> bool:
+        """Whether upgrade is in progress"""
+
+    @property
+    @abc.abstractmethod
+    def unit_status(self) -> tuple[StatusObject | None, dict[str, Any] | None]:
+        """Get unit upgrade status."""
+
+    @property
+    def app_status(self) -> StatusObject | None:
+        """App upgrade status"""
+        if not self.in_progress:
+            return None
+        if not self.is_compatible:
+            logger.info(
+                "Upgrade incompatible. If you accept potential *data loss* and *downtime*, you can continue by running `force-upgrade` action on each remaining unit"
+            )
+            return UpgradesStatuses.UPGRADES_INCOMPATIBLE.value
+        if not self.state.application_upgrade.upgrade_resumed:
+            # User confirmation needed to resume upgrade (i.e. upgrade second unit)
+            # Statuses over 120 characters are truncated in `juju status` as of juju 3.1.6 and
+            # 2.9.45
+            return UpgradesStatuses.UPGRADES_WAITING_FOR_RESUME.value
+        return UpgradesStatuses.UPGRADES_UPGRADING.value
+
+    @abc.abstractmethod
+    def reconcile_partition(self, *, action_event: ops.ActionEvent | None = None) -> None:
+        """If ready, allow next unit to upgrade."""
+
+    @property
+    @abc.abstractmethod
+    def authorized(self) -> bool:
+        """Whether this unit is authorized to upgrade
+
+        Only applies to machine charm
+        """
+
+    @abc.abstractmethod
+    def upgrade_unit(self, *, snap: BaseWorkload) -> None:
+        """Upgrade this unit.
+
+        Only applies to machine charm
+        """
+
+    def pre_upgrade_check(self) -> None:
+        """Check if this app is ready to upgrade
+
+        Runs before any units are upgraded
+
+        Does *not* run during rollback
+
+        On machines, this runs before any units are upgraded (after `juju refresh`)
+        On machines & Kubernetes, this also runs during pre-upgrade-check action
+
+        Can run on leader or non-leader unit
+
+        Raises:
+            PrecheckFailed: App is not ready to upgrade
+
+        TODO Kubernetes: Run (some) checks after `juju refresh` (in case user forgets to run
+        pre-upgrade-check action). Note: 1 unit will upgrade before we can run checks (checks may
+        need to be modified).
+        See https://chat.canonical.com/canonical/pl/cmf6uhm1rp8b7k8gkjkdsj4mya
+        """
+        logger.debug("Running pre-upgrade checks")
+
+        try:
+            deployment_desc = self.state.application.deployment_desc
+            if not deployment_desc:
+                raise OpenSearchUpgradePrecheckError("Deployment description not available")
+
+            online_nodes = self._nodes(
+                use_localhost=self.opensearch_client.is_node_up(),
+                hosts=self.alt_hosts,
+            )
+
+            # Check if all units are marked as started in peer relation data
+            peer_relation = self.state.peer_relation
+            all_units_started = peer_relation is not None and all(
+                peer_relation.data[unit].get("started") for unit in self.state.all_units
+            )
+
+            if (
+                not all_units_started
+                or len([node for node in online_nodes if node.app.id == deployment_desc.app.id])
+                < self.state.model.app.planned_units()
+            ):
+                raise OpenSearchUpgradePrecheckError(
+                    "Not all units are online for the current app."
+                )
+
+        except OpenSearchHttpError:
+            raise OpenSearchUpgradePrecheckError("Cluster is unreachable")
+
+    @override
+    def get_statuses(
+        self, scope: AdvancedStatusesScope, recompute: bool = False
+    ) -> list[StatusObject]:
+        """Compute the manager's statuses."""
+        if not recompute:
+            return self.state.statuses.get(scope, self.name).root or [
+                GeneralStatuses.ACTIVE_IDLE.value
+            ]
+
+        unit_status, unit_dynamic_params = self.unit_status
+        if scope == "unit" and unit_status:
+            return [format_status(unit_status, unit_dynamic_params)]
+
+        if scope == "app" and (status := self.app_status):
+            return [status]
+
+        return [GeneralStatuses.ACTIVE_IDLE.value]
+
+    def override_version(self) -> None:
+        """Override the version on disk to allow rollback to proceed."""
+        self.workload.run_cmd("opensearch.node", "override-version y")
+
+    @property
+    def compatibility_matrix(self) -> dict[str, set[str]]:
+        """Read compatibility matrix from file."""
+        try:
+            content = self.workload.read_text(self.workload.paths.compatibility_matrix)
+            return {key: set(value) for key, value in json.loads(content).items()}
+        except OpenSearchFileOperationError as e:
+            logger.debug("Failed to read compatibility matrix file: %s", str(e))
+            return {}
+        except json.JSONDecodeError as e:
+            logger.error("Failed to decode compatibility matrix file: %s", str(e))
+            return {}
+
+    @compatibility_matrix.setter
+    def compatibility_matrix(self, value: dict[str, set[str]]) -> None:
+        """Write compatibility matrix to file."""
+        try:
+            content = json.dumps({key: list(value) for key, value in value.items()}, indent=4)
+            self.workload.write_text(content, self.workload.paths.compatibility_matrix)
+        except OpenSearchFileOperationError as e:
+            logger.debug("Failed to write compatibility matrix file: %s", str(e))
+
+    def reconcile_compatibility_matrix(self) -> dict[str, set[str]]:
+        """Reconcile compatibility matrix file."""
+        disk_matrix = self.compatibility_matrix
+        current_matrix = UPGRADES_COMPATIBILITY_MATRIX
+        if disk_matrix != current_matrix:
+            # deeply fuse dictionaries
+            for key, value in current_matrix.items():
+                disk_matrix[key] = disk_matrix.setdefault(key, value) | set(value)  # union of sets
+            self.compatibility_matrix = disk_matrix
+            logger.debug("Reconciled compatibility matrix file")
+
+        return disk_matrix
+
+    @property
+    def is_rollback(self) -> bool:
+        """Whether this upgrade is a rollback"""
+        if not self.state.application_upgrade.versions or not (
+            unit_bag_version := self.state.server_upgrade.workload_version_parsed
+        ):
+            return False
+        version_on_disk = self.current_versions.workload_parsed
+        logger.debug("Checking if rollback: %s > %s", str(unit_bag_version), str(version_on_disk))
+        return unit_bag_version > version_on_disk
+
+    @property
+    def can_rollback(self) -> bool:
+        """Whether rollback is supported to previous versions"""
+        if not self.state.application_upgrade.versions or not (
+            unit_bag_version := self.state.server_upgrade.workload_version_parsed
+        ):
+            return False
+
+        version_on_disk = self.current_versions.workload_parsed
+        compatibility_matrix = self.reconcile_compatibility_matrix()
+
+        if (
+            str(unit_bag_version) in compatibility_matrix
+            and str(version_on_disk) in compatibility_matrix[str(unit_bag_version)]
+        ):
+            logger.debug(
+                "Rollback supported from %s to %s",
+                unit_bag_version,
+                version_on_disk,
+            )
+            return True
+
+        logger.warning("Rollback not supported from %s to %s", unit_bag_version, version_on_disk)
+        return False

--- a/opensearch_single_kernel/managers/upgrades_vm.py
+++ b/opensearch_single_kernel/managers/upgrades_vm.py
@@ -71,22 +71,25 @@ class UpgradesManagerVM(UpgradesManagerBase):
 
     def reconcile_partition(self, *, action_event: ops.ActionEvent | None = None) -> None:
         """Handle Juju action to confirm first upgraded unit is healthy and resume upgrade."""
-        if action_event:
-            first_upgrade_unit = self.state.sorted_server_upgrades[0]
-            outdated = first_upgrade_unit.snap_revision != OPENSEARCH_SNAP_REVISION
-            unhealthy = first_upgrade_unit.unit_state is not UnitUpgradesState.HEALTHY
-            if outdated or unhealthy:
-                if outdated:
-                    message = "Highest number unit has not upgraded yet. Upgrade will not resume."
-                else:
-                    message = "Highest number unit is unhealthy. Upgrade will not resume."
-                logger.debug(f"Resume upgrade event failed: {message}")
-                action_event.fail(message)
-                return
-            self.state.application_upgrade.upgrade_resumed = True
-            message = "Upgrade resumed."
-            action_event.set_results({"result": message})
-            logger.debug(f"Resume upgrade event succeeded: {message}")
+        if not action_event:
+            return
+
+        first_upgrade_unit = self.state.sorted_server_upgrades[0]
+        outdated = first_upgrade_unit.snap_revision != OPENSEARCH_SNAP_REVISION
+        unhealthy = first_upgrade_unit.unit_state is not UnitUpgradesState.HEALTHY
+        if outdated or unhealthy:
+            if outdated:
+                message = "Highest number unit has not upgraded yet. Upgrade will not resume."
+            else:
+                message = "Highest number unit is unhealthy. Upgrade will not resume."
+            logger.debug(f"Resume upgrade event failed: {message}")
+            action_event.fail(message)
+            return
+
+        self.state.application_upgrade.upgrade_resumed = True
+        message = "Upgrade resumed."
+        action_event.set_results({"result": message})
+        logger.debug(f"Resume upgrade event succeeded: {message}")
 
     @property
     def authorized(self) -> bool:

--- a/opensearch_single_kernel/managers/upgrades_vm.py
+++ b/opensearch_single_kernel/managers/upgrades_vm.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""In-place upgrades on machines
+
+Derived from specification: DA058 - In-Place Upgrades - Kubernetes v2
+(https://docs.google.com/document/d/1tLjknwHudjcHs42nzPVBNkHs98XxAOT2BXGGpP7NyEU/)
+"""
+import logging
+from typing import Any
+
+import ops
+from data_platform_helpers.advanced_statuses import StatusObject
+
+from opensearch_single_kernel.common.constants import OPENSEARCH_SNAP_REVISION
+from opensearch_single_kernel.common.exceptions import OpenSearchHttpError
+from opensearch_single_kernel.common.statuses import UpgradesStatuses
+from opensearch_single_kernel.core.models import UnitUpgradesState
+from opensearch_single_kernel.managers.upgrades_base import (
+    UpgradesManagerBase,
+)
+from opensearch_single_kernel.workload.base import BaseWorkload
+
+logger = logging.getLogger(__name__)
+
+FORCE_ACTION_NAME = "force-upgrade"
+
+
+class UpgradesManagerVM(UpgradesManagerBase):
+    """In-place upgrades on machines"""
+
+    @property
+    def unit_state(self) -> UnitUpgradesState | None:
+        """Calculate the upgrade state of current unit."""
+        if (
+            snap_revision := self.state.server_upgrade.snap_revision
+        ) is not None and snap_revision != OPENSEARCH_SNAP_REVISION:
+            logger.debug("Unit upgrade state: outdated")
+            return UnitUpgradesState.OUTDATED
+        return self.state.server_upgrade.unit_state
+
+    @property
+    def unit_status(self) -> tuple[StatusObject | None, dict[str, Any] | None]:
+        """Get unit upgrade status."""
+        if not self.in_progress:
+            return (None, None)
+
+        if self.is_rollback:
+            if not self.can_rollback:
+                return UpgradesStatuses.UPGRADES_ROLLBACK_UNSUPPORTED.value, None
+            if self.state.server_upgrade.unit_state is UnitUpgradesState.OUTDATED:
+                return UpgradesStatuses.UPGRADES_ROLLBACK_INCOMPATIBLE.value, None
+
+        if self.state.server_upgrade.snap_revision == OPENSEARCH_SNAP_REVISION:
+            return (
+                UpgradesStatuses.UPGRADES_ACTIVE.value,
+                {
+                    "workload_version": self.state.server_upgrade.workload_version,
+                    "snap_revision": self.state.server_upgrade.snap_revision,
+                    "charm_version": self.current_versions.charm,
+                },
+            )
+        return (
+            UpgradesStatuses.UPGRADES_ACTIVE_OUTDATED.value,
+            {
+                "workload_version": self.state.server_upgrade.workload_version,
+                "snap_revision": self.state.server_upgrade.snap_revision,
+                "charm_version": self.current_versions.charm,
+            },
+        )
+
+    def reconcile_partition(self, *, action_event: ops.ActionEvent | None = None) -> None:
+        """Handle Juju action to confirm first upgraded unit is healthy and resume upgrade."""
+        if action_event:
+            first_upgrade_unit = self.state.sorted_server_upgrades[0]
+            outdated = first_upgrade_unit.snap_revision != OPENSEARCH_SNAP_REVISION
+            unhealthy = first_upgrade_unit.unit_state is not UnitUpgradesState.HEALTHY
+            if outdated or unhealthy:
+                if outdated:
+                    message = "Highest number unit has not upgraded yet. Upgrade will not resume."
+                else:
+                    message = "Highest number unit is unhealthy. Upgrade will not resume."
+                logger.debug(f"Resume upgrade event failed: {message}")
+                action_event.fail(message)
+                return
+            self.state.application_upgrade.upgrade_resumed = True
+            message = "Upgrade resumed."
+            action_event.set_results({"result": message})
+            logger.debug(f"Resume upgrade event succeeded: {message}")
+
+    @property
+    def authorized(self) -> bool:
+        """Whether this unit is authorized to upgrade
+
+        Only applies to machine charm
+
+        Raises:
+            PrecheckFailed: App is not ready to upgrade
+        """
+        assert self.state.server_upgrade.snap_revision != OPENSEARCH_SNAP_REVISION
+        assert self.state.application_upgrade.versions
+        for index, unit in enumerate(self.state.sorted_server_upgrades):
+            if unit.unit == self.state.server.unit:
+                # Higher number units have already upgraded
+                if index == 0:
+                    if (
+                        self.state.application_upgrade.versions.charm
+                        == self.current_versions.charm
+                    ):
+                        # Assumes charm version uniquely identifies charm revision
+                        logger.debug("Rollback detected. Skipping pre-upgrade check")
+                        try:
+                            self.opensearch_client.enable_shard_allocation(
+                                alt_hosts=self.alt_hosts,
+                            )
+                        except OpenSearchHttpError:
+                            logger.exception("Failed to re-enable allocation after rollback")
+                    else:
+                        # Run pre-upgrade check
+                        # (in case user forgot to run pre-upgrade-check action)
+                        self.pre_upgrade_check()
+                        logger.debug("Pre-upgrade check after `juju refresh` successful")
+                elif index == 1:
+                    # User confirmation needed to resume upgrade (i.e. upgrade second unit)
+                    logger.debug(
+                        f"Second unit authorized to upgrade if {self.state.application_upgrade.upgrade_resumed=}"
+                    )
+                    return self.state.application_upgrade.upgrade_resumed
+                return True
+            if (
+                unit.snap_revision != OPENSEARCH_SNAP_REVISION
+                or unit.unit_state is not UnitUpgradesState.HEALTHY
+            ):
+                # Waiting for higher number units to upgrade
+                logger.debug(f"Upgrade not authorized. Waiting for {unit.unit.name=} to upgrade")
+                return False
+        return False
+
+    def upgrade_unit(self, *, snap: BaseWorkload) -> None:
+        """Upgrade this unit.
+
+        Only applies to machine charm
+        """
+        logger.debug("Upgrading unit")
+        self.state.server_upgrade.unit_state = UnitUpgradesState.UPGRADING
+        snap.install()
+        self.state.server_upgrade.snap_revision = OPENSEARCH_SNAP_REVISION
+        self.state.server_upgrade.workload_version = self.current_versions.workload
+        logger.debug(
+            f"Saved {OPENSEARCH_SNAP_REVISION=} and {self.current_versions.workload=} in unit databag after upgrade"
+        )
+
+    def save_snap_revision_after_first_install(self):
+        """Set snap revision on first install"""
+        self.state.server_upgrade.snap_revision = OPENSEARCH_SNAP_REVISION
+        self.state.server_upgrade.workload_version = self.current_versions.workload
+        logger.debug(
+            f"Saved {OPENSEARCH_SNAP_REVISION=} and {self.current_versions.workload=} in unit databag after first install"
+        )
+
+    @property
+    def requires_general_prechecks(self) -> bool:
+        """Whether this unit should run general prechecks before upgrading.
+
+        Returns True only for the first unit in upgrade order (index 0) and only
+        when it's not a rollback. Subsequent units skip general prechecks because
+        the cluster is expected to be yellow during a rolling upgrade.
+        """
+        assert self.state.application_upgrade.versions
+        for index, server in enumerate(self.state.sorted_server_upgrades):
+            if server.unit == self.state.server.unit:
+                is_rollback = (
+                    self.state.application_upgrade.versions.charm == self.current_versions.charm
+                )
+                return index == 0 and not is_rollback
+        return False
+
+    @property
+    def in_progress(self) -> bool:
+        """Whether upgrade is in progress"""
+        return any(
+            server.snap_revision != OPENSEARCH_SNAP_REVISION
+            for server in self.state.sorted_server_upgrades
+            if server.snap_revision
+        )

--- a/opensearch_single_kernel/utils/status.py
+++ b/opensearch_single_kernel/utils/status.py
@@ -27,4 +27,5 @@ def format_status(status: StatusObject, params: dict[str, Any] | None) -> Status
         status=status.status,
         message=status.message.format_map(SafeDict(params)),
         running=status.running,
+        approved_critical_component=status.approved_critical_component,
     )

--- a/opensearch_single_kernel/workload/base.py
+++ b/opensearch_single_kernel/workload/base.py
@@ -39,99 +39,120 @@ class Paths:
             bin: Path to the bin/ folder
     """
 
-    def __init__(self, root: PathProtocol):
+    def __init__(self, root: PathProtocol, charm_root: PathProtocol):
         super().__init__()
         self.root = root
+        self.charm_root = charm_root
 
     @property
     def base_snap_dir(self) -> PathProtocol:
-        """Return path to the Base snap directory."""
+        """Get path to the Base snap directory."""
         return self.root / BASE_SNAP_DIR
 
     @property
     def snap_data(self) -> PathProtocol:
-        """Return path to the snap data directory."""
+        """Get path to the snap data directory."""
         return self.base_snap_dir / SNAP_DATA
 
     @property
     def snap_common(self) -> PathProtocol:
-        """Return path to the snap common directory."""
+        """Get path to the snap common directory."""
         return self.base_snap_dir / SNAP_COMMON
 
     @property
     def snap(self) -> PathProtocol:
-        """Return path to the snap directory."""
+        """Get path to the snap directory."""
         return self.root / SNAP
 
     @property
     def home(self) -> PathProtocol:
-        """Return path to the home snap directory."""
+        """Get path to the home snap directory."""
         return self.snap_data / OpenSearchPaths.HOME.val
 
     @property
     def conf(self) -> PathProtocol:
-        """Return path to the conf snap directory."""
+        """Get path to the conf snap directory."""
         return self.snap_data / OpenSearchPaths.CONF.val
 
     @property
     def opensearch_config(self) -> PathProtocol:
-        """Return path to the opensearch.yml config file."""
+        """Get path to the opensearch.yml config file."""
         return self.conf / "opensearch.yml"
 
     @property
     def opensearch_keystore(self) -> PathProtocol:
-        """Return path to the opensearch keystore."""
+        """Get path to the opensearch keystore."""
         return self.conf / "opensearch.keystore"
 
     @property
     def data(self) -> PathProtocol:
-        """Return path to the data snap directory."""
+        """Get path to the data snap directory."""
         return self.snap_common / OpenSearchPaths.DATA.val
 
     @property
     def logs(self) -> PathProtocol:
-        """Return path to the logs snap directory."""
+        """Get path to the logs snap directory."""
         return self.snap_common / OpenSearchPaths.LOGS.val
 
     @property
     def jdk(self) -> PathProtocol:
-        """Return path to the jdk directory."""
+        """Get path to the jdk directory."""
         return self.snap / OpenSearchPaths.JDK.val
 
     @property
     def tmp(self) -> PathProtocol:
-        """Return path to the tmp directory."""
+        """Get path to the tmp directory."""
         return self.snap_common / OpenSearchPaths.TMP.val
 
     @property
     def bin(self) -> PathProtocol:
-        """Return path to the bin directory."""
+        """Get path to the bin directory."""
         return self.snap / OpenSearchPaths.BIN.val
 
     @property
     def plugins(self) -> PathProtocol:
-        """Returns Plugins Path"""
+        """Get Plugins Path"""
         return self.home / "plugins"
 
     @property
     def certs(self) -> PathProtocol:
-        """Returns Certificates Path"""
+        """Get Certificates Path"""
         return self.conf / "certificates"
 
     @property
     def certs_relative(self) -> str:
-        """Returns Certificates relative Path"""
+        """Get Certificates relative Path"""
         return "certificates"
 
     @property
     def certs_chain(self) -> PathProtocol:
-        """Returns path to the certificates chain file."""
+        """Get path to the certificates chain file."""
         return self.certs / "chain.pem"
 
     @property
     def seed_hosts(self) -> PathProtocol:
-        """Returns path to the Opensearch seed hosts config file."""
+        """Get path to the Opensearch seed hosts config file."""
         return self.conf / "unicast_hosts.txt"
+
+    @property
+    def charm_version(self) -> PathProtocol:
+        """Get path to charm version file."""
+        return self.charm_root / "charm_version"
+
+    @property
+    def workload_version(self) -> PathProtocol:
+        """Get path to workload version file."""
+        return self.charm_root / "workload_version"
+
+    @property
+    def compatibility_matrix(self) -> PathProtocol:
+        """Get path to compatibility matrix file."""
+        return self.data / "compatibility_matrix.json"
+
+    @property
+    def grafana_dashboard(self) -> PathProtocol:
+        """Get path to grafana dashboard file."""
+        return self.charm_root / "src/grafana_dashboards/opensearch.json"
 
 
 # --- Base Workload

--- a/opensearch_single_kernel/workload/vm.py
+++ b/opensearch_single_kernel/workload/vm.py
@@ -8,10 +8,11 @@ import os
 import subprocess
 import tempfile
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 
 from charmlibs import pathops
-from charmlibs.pathops import PathProtocol
+from charmlibs.pathops import LocalPath, PathProtocol
 from overrides import override
 from tenacity import Retrying, retry, stop_after_attempt, wait_exponential, wait_fixed
 
@@ -40,8 +41,9 @@ class VMWorkload(BaseWorkload):
 
     SERVICE_NAME = "daemon"
 
-    def __init__(self):
+    def __init__(self, charm_root: Path):
         super().__init__()
+        self.charm_root = charm_root
         for attempt in Retrying(stop=stop_after_attempt(5), wait=wait_fixed(5)):
             with attempt:
                 cache = snap.SnapCache()
@@ -330,7 +332,7 @@ class VMWorkload(BaseWorkload):
     @override
     def paths(self) -> Paths:
         """Return Workload's paths"""
-        return Paths(self.root)
+        return Paths(self.root, LocalPath(self.charm_root))
 
     @property
     @override

--- a/tests/charms/opensearch_test_charm/actions.yaml
+++ b/tests/charms/opensearch_test_charm/actions.yaml
@@ -86,3 +86,21 @@ status-detail:
       type: boolean
       default: false
       description: a boolean indicating whether a unit should recompute all statuses.   - continue upgrade if 1+ upgraded units have non-active status
+
+# TODO to be changed when implementing refresh V3
+force-refresh-start:
+  description: |
+    Potential of data loss and downtime
+
+    Force refresh of first unit
+
+    Must run with at least one of the parameters `=false`
+  params:
+    check-compatibility:
+      type: boolean
+      default: true
+      description: |
+        Potential of data loss and downtime
+
+        If `false`, force refresh if new version of OpenSearch and/or charm is not compatible with previous version
+  additionalProperties: false

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,4 +6,4 @@
 
 from typing import Literal, TypeAlias
 
-Substrate: TypeAlias = Literal["lxd", "k8s"]
+Substrate: TypeAlias = Literal["vm", "k8s"]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -14,7 +14,7 @@ import tempfile
 from datetime import datetime, timedelta
 from hashlib import md5
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from uuid import uuid4
 
 import requests
@@ -382,6 +382,36 @@ async def wait_until(  # noqa: C901
                 raise Exception
     except RetryError:
         logger.error("wait_until -- Timed out!\n\n\n")
+        logger.info(
+            subprocess.check_output(
+                f"juju status --model {ops_test.model.info.name}", shell=True
+            ).decode("utf-8")
+        )
+        _dump_juju_logs(model=ops_test.model.info.name, lines=3000)
+        raise
+
+
+async def wait_until_condition_on_units(
+    ops_test: OpsTest, app: str, condition: Callable[[list[Unit]], bool], timeout: int = 1200
+) -> None:
+    """Block and wait until a condition is met on the units in `app` or timeout."""
+    try:
+        logger.info("\n\n\n")
+        logger.info(
+            subprocess.check_output(
+                f"juju status --model {ops_test.model.info.name}", shell=True
+            ).decode("utf-8")
+        )
+        for attempt in Retrying(stop=stop_after_delay(timeout), wait=wait_fixed(10)):
+            with attempt:
+                logger.info("Waiting for condition...")
+                units = await get_application_units(ops_test, app)
+                if condition(units):
+                    logger.info(f"{now()} -- Waiting for condition: complete.\n\n\n")
+                    return
+                raise Exception
+    except RetryError:
+        logger.error("wait_until_condition_on_units -- Timed out!\n\n\n")
         logger.info(
             subprocess.check_output(
                 f"juju status --model {ops_test.model.info.name}", shell=True

--- a/tests/integration/upgrades/__init__.py
+++ b/tests/integration/upgrades/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/integration/upgrades/conftest.py
+++ b/tests/integration/upgrades/conftest.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from ..ha.continuous_writes import ContinuousWrites
+from ..helpers import APP_NAME, app_name
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+async def c_writes(ops_test: OpsTest):
+    """Creates instance of the ContinuousWrites."""
+    app = (await app_name(ops_test)) or APP_NAME
+    return ContinuousWrites(ops_test, app)
+
+
+@pytest.fixture(scope="function")
+async def c_writes_runner(ops_test: OpsTest, c_writes: ContinuousWrites):
+    """Starts continuous write operations and clears writes at the end of the test."""
+    await c_writes.start()
+    yield
+    await c_writes.clear()
+    logger.info("\n\n\n\nThe writes have been cleared.\n\n\n\n")

--- a/tests/integration/upgrades/helpers.py
+++ b/tests/integration/upgrades/helpers.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import re
+import subprocess
+import time
+from typing import Optional
+
+import pytest
+from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_attempt, wait_fixed
+
+from opensearch_single_kernel.common.statuses import GeneralStatuses, LockStatuses
+from tests.integration.conftest import CONFIG_OPTS
+
+from ..helpers import (
+    EmptyBlockedStatus,
+    cluster_health,
+    get_application_units,
+    http_request,
+    run_action,
+    wait_until,
+    wait_until_condition_on_units,
+)
+
+OPENSEARCH_CHARM = "opensearch"
+OPENSEARCH_CHANNEL = "2/edge"
+PROFILES_REVISION = 185
+
+TIMEOUT = 2400
+IDLE_PERIOD = 30
+FAST_INTERVAL = "60s"
+
+VERSION_N = "2.19.4"
+VERSION_N_MINUS_1 = "2.18.0"
+VERSION_N_MINUS_2 = "2.17.0"
+
+VERSION_TO_REVISION = {
+    VERSION_N_MINUS_2: {"jammy": 168, "noble": 206},
+    VERSION_N_MINUS_1: {"jammy": 209, "noble": 208},
+}
+
+FROM_VERSION_PREFIX = "from_v{}_to_local"
+
+UPGRADE_PARAMS = [
+    pytest.param(
+        version,
+        id=FROM_VERSION_PREFIX.format(version),
+        marks=pytest.mark.group(
+            id="two_version_upgrade" if version == VERSION_N_MINUS_2 else "one_version_upgrade"
+        ),
+    )
+    for version in VERSION_TO_REVISION.keys()
+]
+
+logger = logging.getLogger(__name__)
+
+
+def testing_config_if_supported(revision: int) -> dict[str, str]:
+    """Returns 'testing' profile config if given revision supports profiles"""
+    return CONFIG_OPTS if revision >= PROFILES_REVISION else {}
+
+
+def refresh(
+    ops_test: OpsTest,
+    app_name: str,
+    *,
+    revision: Optional[int] = None,
+    switch: Optional[str] = None,
+    channel: Optional[str] = None,
+    path: Optional[str] = None,
+    config: Optional[dict[str, str]] = None,
+) -> None:
+    # due to: https://github.com/juju/python-libjuju/issues/1057
+    # the following call does not work:
+    # application = ops_test.model.applications[APP_NAME]
+    # await application.refresh(
+    #     revision=rev,
+    # )
+
+    # Point to the right model, as we are calling the juju cli directly
+    args = [f"--model={ops_test.model.info.name}"]
+    if revision:
+        args.append(f"--revision={revision}")
+    if switch:
+        args.append(f"--switch={switch}")
+    if channel:
+        args.append(f"--channel={channel}")
+    if path:
+        args.append(f"--path={path}")
+    if config:
+        for key, val in config.items():
+            args.extend(["--config", f"{key}={val}"])
+
+    for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(wait=30)):
+        with attempt:
+            cmd = ["juju", "refresh"]
+            cmd.append(app_name)
+            cmd.extend(args)
+            subprocess.check_output(cmd)
+
+
+def get_version_on_unit(unit: str, model: str):
+    """Returns version of OpenSearch running on given unit"""
+    # opensearch.opensearch-bin not exposed in older snap revisions
+    cmd = [
+        "juju",
+        "exec",
+        "--model",
+        model,
+        "--unit",
+        unit,
+        "--",
+        "sudo",
+        "snap",
+        "run",
+        "--shell",
+        "opensearch.daemon",
+        "-c",
+        "$OPENSEARCH_BIN/opensearch --version",
+    ]
+    output = subprocess.check_output(cmd, text=True)
+    match = re.search(r"Version:\s*([0-9]+\.[0-9]+\.[0-9]+)", output)
+    return match.group(1) if match else None
+
+
+async def assert_version_units(ops_test: OpsTest, app: str, expected_version: str):
+    """Ensures all units in given app are running expected OpenSearch version"""
+    logger.info("Ensuring units in '%s' running version %s", app, expected_version)
+
+    units = [f"{app}/{unit.id}" for unit in await get_application_units(ops_test, app)]
+    versions = [get_version_on_unit(unit, ops_test.model.info.name) for unit in units]
+    assert all(
+        version == expected_version for version in versions
+    ), f"Expected {expected_version} on all units, found versions: {list(zip(units, versions))}"
+    logger.info("All units in '%s' running version %s", app, expected_version)
+
+
+async def assert_upgrade_to_revision(
+    ops_test: OpsTest,
+    app: str,
+    revision: int,
+    config: dict[str, str] = {},
+):
+    """Upgrades app to revision"""
+    units = await get_application_units(ops_test, app)
+    leader_id = [u.id for u in units if u.is_leader][0]
+
+    # run pre-upgrade-check action on leader
+    action = await run_action(ops_test, leader_id, "pre-upgrade-check", app=app)
+    logger.info("pre-upgrade-check: %s", action)
+    assert action.status == "completed"
+
+    async with ops_test.fast_forward(fast_interval=FAST_INTERVAL):
+        logger.info("Refreshing '%s' to revision %s", app, revision)
+        refresh(
+            ops_test,
+            app,
+            revision=revision,
+            config=testing_config_if_supported(revision) | config,
+        )
+
+        await wait_until(
+            ops_test,
+            apps=[app],
+            apps_statuses={app: [EmptyBlockedStatus]},
+            wait_for_exact_units={
+                app: len(units),
+            },
+            timeout=TIMEOUT,
+            idle_period=IDLE_PERIOD,
+        )
+
+        # run resume-upgrade action on leader
+        action = await run_action(ops_test, leader_id, "resume-upgrade", app=app)
+        logger.info("resume-upgrade: %s", action)
+        assert action.status == "completed"
+
+        await wait_until(
+            ops_test,
+            apps=[app],
+            timeout=TIMEOUT,
+            idle_period=IDLE_PERIOD,
+        )
+        logger.info("Upgrade of '%s' completed", app)
+
+
+async def assert_upgrade_to_local(
+    ops_test: OpsTest, app: str, charm: str, config: dict[str, str] = {}
+):
+    """Upgrades to local charm"""
+    units = await get_application_units(ops_test, app)
+    leader_id = [u.id for u in units if u.is_leader][0]
+
+    # run pre-upgrade-check action on leader
+    action = await run_action(ops_test, leader_id, "pre-upgrade-check", app=app)
+    logger.info("pre-upgrade-check: %s", action)
+    assert action.status == "completed"
+
+    async with ops_test.fast_forward(fast_interval=FAST_INTERVAL):
+        logger.info("Refreshing '%s' local charm", app)
+        refresh(ops_test, app, path=charm, config=CONFIG_OPTS | config)
+
+        await wait_until(
+            ops_test,
+            apps=[app],
+            apps_statuses={app: [EmptyBlockedStatus]},
+            wait_for_exact_units={
+                app: len(units),
+            },
+            timeout=TIMEOUT,
+            idle_period=IDLE_PERIOD,
+        )
+
+        # run resume-upgrade action on leader
+        action = await run_action(ops_test, leader_id, "resume-upgrade", app=app)
+        logger.info("resume-upgrade: %s", action)
+        assert action.status == "completed"
+
+        await wait_until(
+            ops_test,
+            apps=[app],
+            timeout=TIMEOUT,
+            idle_period=IDLE_PERIOD,
+        )
+        logger.info("Upgrade of '%s' completed", app)
+
+
+async def assert_rollback_to_revision(
+    ops_test: OpsTest,
+    app: str,
+    charm: str,
+    revision: int,
+    config: dict[str, str] = {},
+):
+    """Upgrades to local charm and rolls back to revision mid-upgrade"""
+    units = await get_application_units(ops_test, app)
+    highest_unit_id = sorted([unit.id for unit in units])[-1]
+    leader_id = [unit.id for unit in units if unit.is_leader][0]
+    leader_ip = [unit.ip for unit in units if unit.id == leader_id][0]
+    nodes = await http_request(
+        ops_test,
+        "GET",
+        f"https://{leader_ip}:9200/_cat/nodes?format=json",
+    )
+    cluster_size = len(nodes)
+
+    # run pre-upgrade-check action on leader
+    action = await run_action(ops_test, leader_id, "pre-upgrade-check", app=app)
+    logger.info("pre-upgrade-check: %s", action)
+    assert action.status == "completed"
+
+    n_units = len(units)
+    async with ops_test.fast_forward(fast_interval=FAST_INTERVAL):
+        logger.info("Refreshing '%s' to local charm", app)
+        refresh(ops_test, app, path=charm, config=CONFIG_OPTS | config)
+
+        await wait_until(
+            ops_test,
+            apps=[app],
+            apps_statuses={app: [EmptyBlockedStatus]},
+            wait_for_exact_units={
+                app: n_units,
+            },
+            timeout=TIMEOUT,
+            idle_period=IDLE_PERIOD,
+        )
+
+        # switch to store charm
+        refresh(
+            ops_test,
+            app,
+            switch=OPENSEARCH_CHARM,
+            channel=OPENSEARCH_CHANNEL,
+            config=CONFIG_OPTS | config,
+        )
+
+        time.sleep(5)
+        # roll back to revision
+        logger.info("Rolling back '%s' to revision: %s", app, revision)
+        refresh(
+            ops_test,
+            app,
+            revision=revision,
+            config=testing_config_if_supported(revision) | config,
+        )
+
+        logger.info("Waiting for rolled back unit to attempt restart...")
+
+        await wait_until_condition_on_units(
+            ops_test,
+            app=app,
+            condition=lambda units: any(
+                GeneralStatuses.WAITING_TO_START.value.message
+                in (unit.workload_status.message or "")
+                or unit.workload_status.value
+                == "error"  # the unit may be in an error state on rollback
+                for unit in units
+                if unit.id == highest_unit_id
+            ),
+            timeout=300,
+        )
+
+        await recover_from_rollback(ops_test, app, expected_cluster_size=cluster_size)
+
+        await wait_until(
+            ops_test,
+            apps=[app],
+            wait_for_exact_units={
+                app: n_units,
+            },
+            timeout=TIMEOUT,
+            idle_period=IDLE_PERIOD,
+        )
+        logger.info("Recovery from rollback of '%s' completed", app)
+
+
+async def recover_from_rollback(ops_test: OpsTest, app: str, expected_cluster_size: int):
+    """Recover from refreshing back mid-upgrade"""
+    units = await get_application_units(ops_test, app)
+    rolled_back_unit_id = sorted([unit.id for unit in units])[-1]
+    # make calls to any unit which is not the rolled back unit
+    unit_ip = [unit.ip for unit in units if unit.id != rolled_back_unit_id][0]
+    rolled_back_node = [unit.name for unit in units if unit.id == rolled_back_unit_id][0]
+
+    # re-enable allocation
+    logger.info("Re-enabling cluster routing allocation")
+    await http_request(
+        ops_test,
+        "PUT",
+        f"https://{unit_ip}:9200/_cluster/settings",
+        payload={"persistent": {"cluster.routing.allocation.enable": "all"}},
+    )
+
+    time.sleep(5)
+
+    # get health
+    cluster_health_resp = await cluster_health(ops_test, unit_ip)
+    logger.info("Cluster health response: %s", cluster_health_resp["status"])
+    if cluster_health_resp["status"] == "red":
+        # identify problematic index
+        shards = await http_request(
+            ops_test,
+            "GET",
+            f"https://{unit_ip}:9200/_cat/shards?format=json&h=index,shard,state,unassigned.reason",
+        )
+
+        indices = set()
+        for shard in shards:
+            if (
+                shard.get("state") == "UNASSIGNED"
+                and shard.get("unassigned.reason") == "NODE_LEFT"
+            ):
+                indices.add(shard.get("index"))
+
+        # delete the indices
+        logger.info("Unassigned indices: %s", indices)
+        for index in indices:
+            await http_request(
+                ops_test,
+                "DELETE",
+                f"https://{unit_ip}:9200/{index}",
+            )
+
+        cluster_health_resp = await cluster_health(ops_test, unit_ip)
+        logger.info(
+            "Cluster health response after removing indices: %s", cluster_health_resp["status"]
+        )
+    # add unit
+    logger.info("Adding new unit")
+    await ops_test.model.applications[app].add_unit(count=1)
+
+    # destroy rolled back unit
+    logger.info("Destroying unit '%s/%s'", app, rolled_back_unit_id)
+    await ops_test.model.destroy_unit(
+        f"{app}/{rolled_back_unit_id}", destroy_storage=True, force=True
+    )
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.applications[app].units) == len(units), timeout=300
+    )
+
+    remaining_units = await get_application_units(ops_test, app)
+    new_unit_id = sorted([unit.id for unit in remaining_units])[-1]
+    logger.info("Waiting for new unit '%s/%s'...", app, new_unit_id)
+    await wait_until_condition_on_units(
+        ops_test,
+        app=app,
+        condition=lambda units: any(
+            LockStatuses.REQUEST_LOCK_ON_START.value.message
+            in (unit.workload_status.message or "")  # unit may be stuck waiting for lock
+            or unit.agent_status.value == "idle"
+            for unit in units
+            if unit.id == new_unit_id
+        ),
+        timeout=TIMEOUT,
+    )
+
+    # check if lock with departed unit
+    logger.info("Rolled back OpenSearch node: %s", rolled_back_node)
+    lock_doc = await http_request(
+        ops_test,
+        "GET",
+        f"https://{unit_ip}:9200/.charm_node_lock/_doc/0",
+    )
+    if node_with_lock := lock_doc.get("_source", {}).get("unit-name"):
+        logger.info("Unit with lock: %s", node_with_lock)
+
+        if node_with_lock == rolled_back_node:
+            logger.info("Deleting lock document")
+            await http_request(
+                ops_test,
+                "DELETE",
+                f"https://{unit_ip}:9200/.charm_node_lock/_doc/0?refresh=true",
+            )
+
+    await wait_until(
+        ops_test,
+        apps=[app],
+        wait_for_exact_units=len(remaining_units),
+        timeout=TIMEOUT,
+        idle_period=IDLE_PERIOD,
+    )
+
+    # verify node joined cluster
+    nodes = await http_request(
+        ops_test,
+        "GET",
+        f"https://{unit_ip}:9200/_cat/nodes?format=json",
+    )
+    node_names = [node["name"] for node in nodes]
+    logger.info("Nodes in cluster: %s", ", ".join(node_names))
+
+    new_node_name = [unit.name for unit in remaining_units if unit.id == new_unit_id][0]
+    assert new_node_name in node_names, f"Replacement node '{new_node_name}' not found in cluster."
+    assert (
+        len(nodes) == expected_cluster_size
+    ), f"Expected cluster size of {expected_cluster_size} but found {len(nodes)}"

--- a/tests/integration/upgrades/test_manual_large_deployment_upgrades.py
+++ b/tests/integration/upgrades/test_manual_large_deployment_upgrades.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from opensearch_single_kernel.common.statuses import PeerClusterStatuses
+from tests.integration.conftest import MODEL_CONFIG
+
+from ..ha.continuous_writes import ContinuousWrites
+from ..ha.helpers import (
+    assert_continuous_writes_consistency,
+    assert_continuous_writes_increasing,
+)
+from ..helpers import APP_NAME, set_watermark, wait_until
+from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
+from .helpers import (
+    IDLE_PERIOD,
+    OPENSEARCH_CHANNEL,
+    OPENSEARCH_CHARM,
+    UPGRADE_PARAMS,
+    VERSION_N,
+    VERSION_N_MINUS_1,
+    VERSION_N_MINUS_2,
+    VERSION_TO_REVISION,
+    assert_rollback_to_revision,
+    assert_upgrade_to_local,
+    assert_upgrade_to_revision,
+    assert_version_units,
+    testing_config_if_supported,
+)
+
+logger = logging.getLogger(__name__)
+
+MAIN_APP = "main"
+FAILOVER_APP = "failover"
+
+REL_ORCHESTRATOR = "peer-cluster-orchestrator"
+REL_PEER = "peer-cluster"
+TIMEOUT = 1800
+
+charm = None
+
+APPS = {
+    APP_NAME: 3,
+    FAILOVER_APP: 2,
+    MAIN_APP: 3,
+}
+
+
+async def _build_env(ops_test: OpsTest, version: str, series: str) -> None:
+    """Sets up environment for given version and series"""
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    # Deploy TLS Certificates operator.
+    tls_config = {"ca-common-name": "CN_CA"}
+
+    revision = VERSION_TO_REVISION[version][series]
+    config = testing_config_if_supported(revision)
+    await asyncio.gather(
+        ops_test.model.deploy(
+            TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=tls_config
+        ),
+        ops_test.model.deploy(
+            OPENSEARCH_CHARM,
+            channel=OPENSEARCH_CHANNEL,
+            application_name=MAIN_APP,
+            num_units=APPS[MAIN_APP],
+            revision=revision,
+            series=series,
+            config={"cluster_name": "upgrades"} | config,
+        ),
+        ops_test.model.deploy(
+            OPENSEARCH_CHARM,
+            channel=OPENSEARCH_CHANNEL,
+            application_name=FAILOVER_APP,
+            num_units=APPS[FAILOVER_APP],
+            revision=revision,
+            series=series,
+            config={"cluster_name": "upgrades", "init_hold": True, "roles": "cluster_manager"}
+            | config,
+        ),
+        ops_test.model.deploy(
+            OPENSEARCH_CHARM,
+            channel=OPENSEARCH_CHANNEL,
+            application_name=APP_NAME,
+            num_units=APPS[APP_NAME],
+            revision=revision,
+            series=series,
+            config={"cluster_name": "upgrades", "init_hold": True, "roles": "data"} | config,
+        ),
+    )
+
+    # integrate TLS to all applications
+    for app in list(APPS.keys()):
+        await ops_test.model.integrate(app, TLS_CERTIFICATES_APP_NAME)
+
+    await wait_until(
+        ops_test,
+        apps=list(APPS.keys()),
+        apps_statuses={
+            FAILOVER_APP: [PeerClusterStatuses.PEER_CLUSTER_NO_RELATION.value],
+            APP_NAME: [PeerClusterStatuses.PEER_CLUSTER_NO_RELATION.value],
+        },
+        wait_for_exact_units={app: units for app, units in APPS.items()},
+        idle_period=IDLE_PERIOD,
+        timeout=TIMEOUT,
+    )
+
+    await ops_test.model.integrate(f"{MAIN_APP}:{REL_ORCHESTRATOR}", f"{APP_NAME}:{REL_PEER}")
+    await ops_test.model.integrate(f"{MAIN_APP}:{REL_ORCHESTRATOR}", f"{FAILOVER_APP}:{REL_PEER}")
+    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_ORCHESTRATOR}", f"{APP_NAME}:{REL_PEER}")
+
+    await wait_until(
+        ops_test,
+        apps=list(APPS.keys()),
+        wait_for_exact_units={app: units for app, units in APPS.items()},
+        idle_period=IDLE_PERIOD,
+        timeout=TIMEOUT,
+    )
+
+    for app in list(APPS.keys()):
+        await set_watermark(ops_test, app)
+
+
+@pytest.mark.group(id="happy_path_upgrade")
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_deploy_starting_version(ops_test: OpsTest, series) -> None:
+    """Build and deploy the charm for large deployment tests."""
+    # deploy version n-2 for current series
+    await _build_env(ops_test, VERSION_N_MINUS_2, series)
+
+
+@pytest.mark.group(id="happy_path_upgrade")
+@pytest.mark.abort_on_fail
+@pytest.mark.skip("Can't upgrade between earlier versions")
+# TODO: re-enable after two versions available
+async def test_upgrade_to_n_minus_1(
+    ops_test: OpsTest, series: str, c_writes: ContinuousWrites, c_writes_runner
+) -> None:
+    """Test minor version upgrade from n-2 to n-1."""
+    # upgrade to version n-1 revision for current series
+    revision = VERSION_TO_REVISION[VERSION_N_MINUS_1][series]
+    for app in list(APPS.keys()):
+        await assert_version_units(ops_test, app, VERSION_N_MINUS_2)
+        await assert_upgrade_to_revision(ops_test, app, revision)
+        await assert_version_units(ops_test, app, VERSION_N_MINUS_1)
+
+    # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
+    await assert_continuous_writes_consistency(ops_test, c_writes, [APP_NAME, MAIN_APP])
+
+
+@pytest.mark.group(id="happy_path_upgrade")
+@pytest.mark.abort_on_fail
+async def test_upgrade_to_local(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner, charm
+) -> None:
+    """Test upgrade to local charm from n-1."""
+    for app in [APP_NAME, FAILOVER_APP, MAIN_APP]:
+        await assert_upgrade_to_local(ops_test, app=app, charm=charm)
+        await assert_version_units(ops_test, app, VERSION_N)
+
+    # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
+    await assert_continuous_writes_consistency(ops_test, c_writes, [APP_NAME, MAIN_APP])
+
+
+@pytest.mark.parametrize("version", UPGRADE_PARAMS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_deploy_version(ops_test: OpsTest, version, series) -> None:
+    """Deploy OpenSearch at given version."""
+    await _build_env(ops_test, version, series)
+
+
+@pytest.mark.parametrize("version", UPGRADE_PARAMS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip("Rollbacks not supported")
+# TODO re-enable after rollbacks best effort support is added
+async def test_upgrade_rollback_from_local(
+    ops_test: OpsTest,
+    version: str,
+    charm: str,
+    series: str,
+    c_writes: ContinuousWrites,
+    c_writes_runner,
+) -> None:
+    """Test upgrade to local and rollback to given version."""
+    revision = VERSION_TO_REVISION[version][series]
+    for app in [APP_NAME, FAILOVER_APP, MAIN_APP]:
+        await assert_version_units(ops_test, app, version)
+        await assert_rollback_to_revision(ops_test, app, charm, revision)
+        await assert_version_units(ops_test, app, version)
+
+    # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
+    await assert_continuous_writes_consistency(ops_test, c_writes, [APP_NAME, MAIN_APP])
+
+
+@pytest.mark.parametrize("version", UPGRADE_PARAMS)
+@pytest.mark.abort_on_fail
+async def test_upgrade_from_version_to_local(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner, version, charm
+) -> None:
+    """Test upgrade from usptream to local charm."""
+    for app in [APP_NAME, FAILOVER_APP, MAIN_APP]:
+        await assert_upgrade_to_local(ops_test, app=app, charm=charm)
+        await assert_version_units(ops_test, app, VERSION_N)
+
+    # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
+    await assert_continuous_writes_consistency(ops_test, c_writes, [APP_NAME, MAIN_APP])

--- a/tests/integration/upgrades/test_small_deployment_upgrades.py
+++ b/tests/integration/upgrades/test_small_deployment_upgrades.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.conftest import CONFIG_OPTS, MODEL_CONFIG
+
+from ..ha.continuous_writes import ContinuousWrites
+from ..ha.helpers import (
+    assert_continuous_writes_consistency,
+    assert_continuous_writes_increasing,
+)
+from ..helpers import APP_NAME, app_name, set_watermark, wait_until
+from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
+from .helpers import (
+    PROFILES_REVISION,
+    UPGRADE_PARAMS,
+    VERSION_N,
+    VERSION_N_MINUS_1,
+    VERSION_N_MINUS_2,
+    VERSION_TO_REVISION,
+    assert_rollback_to_revision,
+    assert_upgrade_to_local,
+    assert_upgrade_to_revision,
+    assert_version_units,
+)
+
+logger = logging.getLogger(__name__)
+
+
+OPENSEARCH_ORIGINAL_CHARM_NAME = "opensearch"
+OPENSEARCH_CHANNEL = "2/edge"
+
+charm = None
+
+
+#######################################################################
+#
+#  Auxiliary functions
+#
+#######################################################################
+
+
+async def _build_env(ops_test: OpsTest, version: str, series) -> None:
+    """Deploy OpenSearch cluster from a given revision."""
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    revision = VERSION_TO_REVISION[version][series]
+    await ops_test.model.deploy(
+        OPENSEARCH_ORIGINAL_CHARM_NAME,
+        application_name=APP_NAME,
+        num_units=3,
+        channel=OPENSEARCH_CHANNEL,
+        revision=revision,
+        series=series,
+        config=CONFIG_OPTS if revision > PROFILES_REVISION else {},
+    )
+
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await ops_test.model.deploy(
+        TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
+    )
+
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await wait_until(
+        ops_test,
+        apps=[TLS_CERTIFICATES_APP_NAME, APP_NAME],
+        timeout=1400,
+        wait_for_exact_units={
+            APP_NAME: 3,
+        },
+        idle_period=60,
+    )
+
+    await set_watermark(ops_test, APP_NAME)
+
+
+#######################################################################
+#
+#  Tests
+#
+#######################################################################
+
+
+@pytest.mark.group(id="happy_path_upgrade")
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_deploy_latest_from_channel(ops_test: OpsTest, series) -> None:
+    """Deploy OpenSearch."""
+    await _build_env(ops_test, VERSION_N_MINUS_2, series)
+
+
+@pytest.mark.group(id="happy_path_upgrade")
+@pytest.mark.abort_on_fail
+@pytest.mark.skip("Can't upgrade between earlier versions")
+# TODO: re-enable after two versions available
+async def test_upgrade_to_n_minus_1(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner, series
+) -> None:
+    """Test upgrade from upstream (n-2) to currently n-1 built version."""
+    app = (await app_name(ops_test)) or APP_NAME
+    revision = VERSION_TO_REVISION[VERSION_N_MINUS_1][series]
+    await assert_version_units(ops_test, app, VERSION_N_MINUS_2)
+    await assert_upgrade_to_revision(ops_test, app=app, revision=revision)
+    await assert_version_units(ops_test, app, VERSION_N_MINUS_1)
+
+    # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
+    await assert_continuous_writes_consistency(ops_test, c_writes, [app])
+
+
+@pytest.mark.group(id="happy_path_upgrade")
+@pytest.mark.abort_on_fail
+async def test_upgrade_to_local(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner, charm
+) -> None:
+    """Test upgrade from n-1 to currently locally built version."""
+    app = (await app_name(ops_test)) or APP_NAME
+    await assert_upgrade_to_local(ops_test, app=app, charm=charm)
+    await assert_version_units(ops_test, app, VERSION_N)
+
+    # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
+    await assert_continuous_writes_consistency(ops_test, c_writes, [app])
+
+
+##################################################################################
+#
+#  test scenarios from each version:
+#    Start with each version, moving to local and then rolling back mid-upgrade
+#    Once this test passes, the 2nd test will rerun the upgrade, this time to
+#    its end.
+#
+##################################################################################
+
+
+@pytest.mark.parametrize("version", UPGRADE_PARAMS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_deploy_from_version(ops_test: OpsTest, version, series) -> None:
+    """Deploy OpenSearch."""
+    await _build_env(ops_test, version, series)
+
+
+@pytest.mark.parametrize("version", UPGRADE_PARAMS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip("Rollbacks not supported")
+# TODO re-enable after rollbacks best effort support is added
+async def test_upgrade_rollback_from_local(ops_test: OpsTest, version, charm, series) -> None:
+    """Test upgrade and rollback to each version available."""
+    app = (await app_name(ops_test)) or APP_NAME
+    revision = VERSION_TO_REVISION[version][series]
+    await assert_version_units(ops_test, app, version)
+    await assert_rollback_to_revision(ops_test, app=app, charm=charm, revision=revision)
+    await assert_version_units(ops_test, app, version)
+
+
+@pytest.mark.parametrize("version", UPGRADE_PARAMS)
+@pytest.mark.abort_on_fail
+async def test_upgrade_from_version_to_local(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner, version, charm
+) -> None:
+    """Test upgrade from usptream to currently locally built version."""
+    app = (await app_name(ops_test)) or APP_NAME
+    await assert_upgrade_to_local(ops_test, app=app, charm=charm)
+    await assert_version_units(ops_test, app, VERSION_N)
+
+    # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
+    await assert_continuous_writes_consistency(ops_test, c_writes, [app])

--- a/tests/spread/vm/test_small_deployment_upgrades.py-happy_path/task.yaml
+++ b/tests/spread/vm/test_small_deployment_upgrades.py-happy_path/task.yaml
@@ -1,0 +1,9 @@
+summary: test_small_deployment_upgrades.py
+environment:
+  TEST_MODULE: upgrades/test_small_deployment_upgrades.py
+systems:
+  - self-hosted-linux-amd64-noble-large
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate vm --model testing --alluredir="$SPREAD_TASK/allure-results" -m 'group(id="happy_path_upgrade")'
+artifacts:
+  - allure-results

--- a/tests/spread/vm/test_small_deployment_upgrades.py-one_version_upgrade/task.yaml
+++ b/tests/spread/vm/test_small_deployment_upgrades.py-one_version_upgrade/task.yaml
@@ -1,0 +1,9 @@
+summary: test_small_deployment_upgrades.py
+environment:
+  TEST_MODULE: upgrades/test_small_deployment_upgrades.py
+systems:
+  - self-hosted-linux-amd64-noble-large
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate vm --model testing --alluredir="$SPREAD_TASK/allure-results" -m 'group(id="one_version_upgrade")'
+artifacts:
+  - allure-results

--- a/tests/spread/vm/test_small_deployment_upgrades.py-two_version_upgrade/task.yaml
+++ b/tests/spread/vm/test_small_deployment_upgrades.py-two_version_upgrade/task.yaml
@@ -1,0 +1,9 @@
+summary: test_small_deployment_upgrades.py
+environment:
+  TEST_MODULE: upgrades/test_small_deployment_upgrades.py
+systems:
+  - self-hosted-linux-amd64-noble-large
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate vm --model testing --alluredir="$SPREAD_TASK/allure-results" -m 'group(id="two_version_upgrade")'
+artifacts:
+  - allure-results

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
+from unittest.mock import PropertyMock
 
 import pytest
 import yaml
@@ -16,7 +17,9 @@ from opensearch_single_kernel.common.constants import (
     PEER_RELATION,
     S3_RELATION,
     TLS_RELATION,
+    UPGRADE_RELATION,
 )
+from opensearch_single_kernel.core.models import UpgradeVersions
 from tests.helpers import Substrate
 from tests.unit.constants import DEFAULT_AZURE_INFO, DEFAULT_GCS_INFO, DEFAULT_S3_INFO
 
@@ -41,12 +44,25 @@ def harness(substrate: Substrate, opensearch_base_path: Path, mocker) -> Harness
     actions = str(yaml.safe_load((opensearch_base_path / "actions.yaml").read_text()))
     metadata = str(yaml.safe_load((opensearch_base_path / "metadata.yaml").read_text()))
 
+    # _current_versions is a @property that reads version files via read_text(), which is mocked to
+    # return MagicMock by mock_fs_interactions. Patch it as a PropertyMock before begin() so all
+    # events (including upgrade relation_created) see valid version strings.
+    mocker.patch(
+        "opensearch_single_kernel.managers.upgrades_base.UpgradesManagerBase.current_versions",
+        new_callable=PropertyMock,
+        return_value=UpgradeVersions(charm="1.0.0", workload="2.19.4"),
+    )
+    mocker.patch(
+        "opensearch_single_kernel.managers.upgrades_base.UpgradesManagerBase.reconcile_compatibility_matrix",
+    )
+
     harness = Harness(TestCharm, meta=metadata, actions=actions, config=config)
     harness.add_network("1.1.1.1")
     harness.add_network("1.1.1.1", endpoint=TLS_RELATION)
     harness.begin()
     rel_id = harness.add_relation(PEER_RELATION, harness.charm.app.name)
     harness.add_relation_unit(rel_id, f"{harness.charm.app.name}/0")
+    harness.add_relation(UPGRADE_RELATION, harness.charm.app.name)
     harness.add_relation(TLS_RELATION, harness.charm.app.name),
 
     return harness
@@ -72,6 +88,9 @@ def mock_fs_interactions(mocker, substrate: Substrate, request) -> None:
     mocker.patch("charmlibs.pathops.LocalPath.write_text")
     mocker.patch("charmlibs.pathops.LocalPath.mkdir")
     mocker.patch("charmlibs.pathops.LocalPath.unlink")
+
+    if substrate == "vm":
+        mocker.patch("opensearch_single_kernel.lib.charms.operator_libs_linux.v2.snap.SnapCache")
 
 
 # ---- Backup and Restore related fixtures ---- #

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -636,6 +636,10 @@ def test_prereq_when_upgrade_in_progress_then_action_fails(
         "opensearch_single_kernel.managers.upgrades_vm.UpgradesManagerVM.in_progress",
         new_callable=PropertyMock(return_value=True),
     )
+    mocker.patch(
+        "opensearch_single_kernel.managers.upgrades_base.UpgradesManagerBase.get_statuses",
+        return_value=[],
+    )
 
     _mock_backup(mocker)
     backend, rels = backend_setup

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -62,7 +62,7 @@ def _mock_backup(
 
 
 def test_create_backup_when_manager_raises_http_error_then_action_fails(
-    mocker, backend_setup, context
+    mocker, harness, backend_setup, context
 ):
     # Given
     create_snapshot = mocker.patch(
@@ -628,18 +628,36 @@ def test_prereq_when_deployment_not_ready_then_action_fails(
     assert "deployment not ready" in err.value.message.lower()
 
 
-# TODO: Re-enable this test when upgrade is implemented
-@pytest.mark.skip(reason="Upgrade not implemented yet")
-def test_prereq_when_upgrade_in_progress_then_action_fails(self, monkeypatch):
-    st = testing.State(leader=True)
-    monkeypatch.setattr(
-        "src.charm.OpenSearchOperatorCharm.upgrade_in_progress",
-        property(lambda _self: True),
+def test_prereq_when_upgrade_in_progress_then_action_fails(
+    context, mocker, harness, backend_setup, monkeypatch
+):
+    # Given
+    mocker.patch(
+        "opensearch_single_kernel.managers.upgrades_vm.UpgradesManagerVM.in_progress",
+        new_callable=PropertyMock(return_value=True),
     )
 
-    with pytest.raises(testing.ActionFailed) as err:
-        self.ctx.run(self.ctx.on.action("create-backup"), st)
+    _mock_backup(mocker)
+    backend, rels = backend_setup
+    if backend == "s3":
+        object_storage_type = ObjectStorageType.S3
+    elif backend == "azure":
+        object_storage_type = ObjectStorageType.AZURE
+    else:
+        object_storage_type = ObjectStorageType.GCS
 
+    mocker.patch(
+        "opensearch_single_kernel.core.state.ClusterState.storage_type",
+        new_callable=PropertyMock,
+        return_value=object_storage_type,
+    )
+
+    st = testing.State(leader=True, relations=rels)
+
+    # When
+    with pytest.raises(testing.ActionFailed) as err:
+        context.run(context.on.action("create-backup"), st)
+    # Assert
     assert "upgrade in-progress" in err.value.message.lower()
 
 

--- a/tests/unit/test_tls_manager.py
+++ b/tests/unit/test_tls_manager.py
@@ -1066,10 +1066,6 @@ def test_on_certificate_available_ca_rotation_second_stage_any_cluster_leader(
         app=App(model_uuid=harness.charm.model.uuid, name=harness.charm.app.name),
         state=DeploymentState(value=State.ACTIVE),
     )
-    # TODO: Re enable mock over upgrade
-    # upgrade_mock = MagicMock(app_status=ActiveStatus())
-    # upgrade_mock.get_unit_juju_status.return_value = ActiveStatus()
-    # upgrade.return_value = upgrade_mock
 
     mock_response_root(harness.charm.state.unit_name, harness.charm.state.host_ip)
     mock_response_nodes(harness.charm.state.unit_name, harness.charm.state.host_ip)
@@ -1234,10 +1230,6 @@ def test_on_certificate_available_ca_rotation_second_stage_any_cluster_non_leade
         app=App(model_uuid=harness.charm.model.uuid, name=harness.charm.app.name),
         state=DeploymentState(value=State.ACTIVE),
     )
-    # TODO: Re enable mock over upgrade
-    # upgrade_mock = MagicMock(app_status=ActiveStatus())
-    # upgrade_mock.get_unit_juju_status.return_value = ActiveStatus()
-    # upgrade.return_value = upgrade_mock
 
     mock_response_root(harness.charm.state.unit_name, harness.charm.state.host_ip)
     mock_response_nodes(harness.charm.state.unit_name, harness.charm.state.host_ip)


### PR DESCRIPTION
Key points:
* ported upgrades code from OG Opensearch (including latest commit from @skourta) and re-enabled all of the code parts that were disabled due to upgrades unavailability;
* charm_dir is now passed to workload for use in Paths;
* all introduced charm statuses moved to advanced status lib and marked with `approved_critical_component=True`;
* all relation bag interactions moved to the state;
* the `apply_health_during_upgrade` function was removed due to redundancy;
* all of the upgrades event handling is now in single `UpgradesEventsHandler` instead of being spread all over codebase;
* upgrades manager is still an inherited class both for VM & K8s (although only VM is implemented);
* lifecycle checks were also ported (with subordinate parts removed due to redundancy);
* small deployment integration tests for upgrades were also ported.