### PR TITLE
patch: move to canonical k8s on ci

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -136,6 +136,10 @@ jobs:
           GCP_ACCESS_KEY: ${{ secrets.GCP_ACCESS_KEY }}
           GCP_SECRET_KEY: ${{ secrets.GCP_SECRET_KEY }}
           GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
+
       - name: Upload Allure results
         timeout-minutes: 3
         # Only upload results from one spread system & one spread variant

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -139,6 +139,7 @@ jobs:
 
       - name: Setup tmate session
         uses: canonical/action-tmate@main
+        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) }}
 
       - name: Upload Allure results
         timeout-minutes: 3

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -102,7 +102,6 @@ jobs:
         # Completely purging Docker requires also
         # deleting the Docker-specific `iptables-nft` rulesets
         # created on installation.
-        if: ${{ inputs.path-to-charm-directory == 'kubernetes' }}
         timeout-minutes: 5
         run: |
           sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io docker.io containerd 2>/dev/null || true
@@ -118,7 +117,6 @@ jobs:
         # pods onto the 10.88.0.0/16 bridge instead of the Cilium pod
         # CIDR. Removing the file ensures Cilium is the only CNI plugin
         # from the start.
-        if: ${{ inputs.path-to-charm-directory == 'kubernetes' }}
         timeout-minutes: 1
         run: |
           sudo rm -f /etc/cni/net.d/87-podman-bridge.conflist

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -93,6 +93,35 @@ jobs:
       - name: Disk usage
         timeout-minutes: 1
         run: df --human-readable
+      - name: Purge Docker
+        # GitHub-hosted Azure runners ship Docker pre-installed and active.
+        # Canonical K8s requires "A system with no previous installations
+        # of containerd/docker as this may cause conflicts"
+        # (see https://documentation.ubuntu.com/canonical-kubernetes
+        # /release-1.32/snap/tutorial/getting-started/).
+        # Completely purging Docker requires also
+        # deleting the Docker-specific `iptables-nft` rulesets
+        # created on installation.
+        if: ${{ inputs.path-to-charm-directory == 'kubernetes' }}
+        timeout-minutes: 5
+        run: |
+          sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io docker.io containerd 2>/dev/null || true
+          sudo nft flush ruleset
+          sudo ip link delete docker0 2>/dev/null || true
+      - name: Remove podman CNI bridge config
+        # Ubuntu 24.04 runners ship podman with a CNI bridge config
+        # (/etc/cni/net.d/87-podman-bridge.conflist) that sorts
+        # lexicographically before Cilium's config (05-cilium.conflist).
+        # When that file is present, containerd picks the podman bridge
+        # as the active CNI before Cilium is ready, bypassing the
+        # node.kubernetes.io/network-unavailable taint and scheduling
+        # pods onto the 10.88.0.0/16 bridge instead of the Cilium pod
+        # CIDR. Removing the file ensures Cilium is the only CNI plugin
+        # from the start.
+        if: ${{ inputs.path-to-charm-directory == 'kubernetes' }}
+        timeout-minutes: 1
+        run: |
+          sudo rm -f /etc/cni/net.d/87-podman-bridge.conflist
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v4

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -93,33 +93,6 @@ jobs:
       - name: Disk usage
         timeout-minutes: 1
         run: df --human-readable
-      - name: Purge Docker
-        # GitHub-hosted Azure runners ship Docker pre-installed and active.
-        # Canonical K8s requires "A system with no previous installations
-        # of containerd/docker as this may cause conflicts"
-        # (see https://documentation.ubuntu.com/canonical-kubernetes
-        # /release-1.32/snap/tutorial/getting-started/).
-        # Completely purging Docker requires also
-        # deleting the Docker-specific `iptables-nft` rulesets
-        # created on installation.
-        timeout-minutes: 5
-        run: |
-          sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io docker.io containerd 2>/dev/null || true
-          sudo nft flush ruleset
-          sudo ip link delete docker0 2>/dev/null || true
-      - name: Remove podman CNI bridge config
-        # Ubuntu 24.04 runners ship podman with a CNI bridge config
-        # (/etc/cni/net.d/87-podman-bridge.conflist) that sorts
-        # lexicographically before Cilium's config (05-cilium.conflist).
-        # When that file is present, containerd picks the podman bridge
-        # as the active CNI before Cilium is ready, bypassing the
-        # node.kubernetes.io/network-unavailable taint and scheduling
-        # pods onto the 10.88.0.0/16 bridge instead of the Cilium pod
-        # CIDR. Removing the file ensures Cilium is the only CNI plugin
-        # from the start.
-        timeout-minutes: 1
-        run: |
-          sudo rm -f /etc/cni/net.d/87-podman-bridge.conflist
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v4

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -137,10 +137,6 @@ jobs:
           GCP_SECRET_KEY: ${{ secrets.GCP_SECRET_KEY }}
           GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Setup tmate session
-        uses: canonical/action-tmate@main
-        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) }}
-
       - name: Upload Allure results
         timeout-minutes: 3
         # Only upload results from one spread system & one spread variant

--- a/concierge-k8s.yaml
+++ b/concierge-k8s.yaml
@@ -9,13 +9,12 @@ juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
 providers:
-  microk8s:
+  k8s:
     enable: true
     bootstrap: true
-    addons:
-      - dns
-      - hostpath-storage
-      - metallb:10.64.140.43-10.64.140.49
+    channel: 1.32-classic/stable
+    bootstrap-constraints:
+      root-disk: 5G
 
 host:
   snaps:

--- a/concierge-k8s.yaml
+++ b/concierge-k8s.yaml
@@ -15,6 +15,8 @@ providers:
     channel: 1.32-classic/stable
     bootstrap-constraints:
       root-disk: 5G
+    image-registry:
+      url: $DOCKERHUB_MIRROR
 
 host:
   snaps:

--- a/spread.yaml
+++ b/spread.yaml
@@ -104,6 +104,7 @@ backends:
       GCP_SERVICE_ACCOUNT: "$(HOST: echo $GCP_SERVICE_ACCOUNT)"
       AZURE_STORAGE_ACCOUNT: "$(HOST: echo $AZURE_STORAGE_ACCOUNT)"
       AZURE_SECRET_KEY: "$(HOST: echo $AZURE_SECRET_KEY)"
+      DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
       CONCIERGE_EXTRA_DEBS: pipx
     systems:
       - self-hosted-linux-amd64-noble-medium:
@@ -132,6 +133,15 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
+  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
+  then
+    mkdir -p /var/snap/k8s/common/etc/containerd/certs.d/docker.io
+    tee /var/snap/k8s/common/etc/containerd/certs.d/docker.io/hosts.toml << EOF
+    server = "$DOCKERHUB_MIRROR"
+    [host."${DOCKERHUB_MIRROR#'https://'}"]
+    capabilities = ["pull", "resolve"]
+  EOF
+  fi
 
   if [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
   then

--- a/spread.yaml
+++ b/spread.yaml
@@ -135,6 +135,18 @@ prepare: |
 
   if [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
   then
+  # Remove docker and fix iptable forwarding rules to avoid conflicts with k8s and cilium
+    sudo apt-get purge -y docker.io containerd 2>/dev/null || true
+    sudo apt-get autoremove -y 2>/dev/null || true
+    for chain in DOCKER DOCKER-ISOLATION-STAGE-1 DOCKER-ISOLATION-STAGE-2 DOCKER-USER DOCKER-FORWARD; do
+      sudo iptables -D FORWARD -j $chain 2>/dev/null || true
+      sudo iptables -F $chain 2>/dev/null || true
+      sudo iptables -X $chain 2>/dev/null || true
+      sudo iptables -t nat -F $chain 2>/dev/null || true
+      sudo iptables -t nat -X $chain 2>/dev/null || true
+    done
+    sudo iptables -P FORWARD ACCEPT
+
     concierge prepare --trace -c concierge-k8s.yaml
     # k8s status --wait-ready returns as soon as 1 node is ready
     # (see https://github.com/canonical/k8s-snap/issues/1789)

--- a/spread.yaml
+++ b/spread.yaml
@@ -62,11 +62,11 @@ backends:
       git restore pyproject.toml poetry.lock
 
       # Use instead of `concierge restore` to save time between tests
-      # For example, with microk8s, using `concierge restore` takes twice as long as this (e.g. 6
+      # For example, with k8s, using `concierge restore` takes twice as long as this (e.g. 6
       # min instead of 3 min between every spread job)
-      juju destroy-model --force --no-wait --destroy-storage --no-prompt concierge-microk8s:testing
+      juju destroy-model --force --no-wait --destroy-storage --no-prompt concierge-k8s:testing
       juju destroy-model --force --no-wait --destroy-storage --no-prompt concierge-lxd:testing
-      juju kill-controller --no-prompt concierge-microk8s
+      juju kill-controller --no-prompt concierge-k8s
       juju kill-controller --no-prompt concierge-lxd
     restore: |
       rm -rf "$SPREAD_PATH"
@@ -104,8 +104,6 @@ backends:
       GCP_SERVICE_ACCOUNT: "$(HOST: echo $GCP_SERVICE_ACCOUNT)"
       AZURE_STORAGE_ACCOUNT: "$(HOST: echo $AZURE_STORAGE_ACCOUNT)"
       AZURE_SECRET_KEY: "$(HOST: echo $AZURE_SECRET_KEY)"
-      DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
-      CONCIERGE_MICROK8S_CHANNEL: 1.34-strict/stable
       CONCIERGE_EXTRA_DEBS: pipx
     systems:
       - self-hosted-linux-amd64-noble-medium:
@@ -134,36 +132,20 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
-  then
-    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
-    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
-
-    snap install microk8s --channel "$CONCIERGE_MICROK8S_CHANNEL" --classic
-
-    # Wait for microk8s to populate iptables
-    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
-    until [[ -n $(iptables --list | grep -i "microk8s") ]]
-    do
-      echo "MicroK8s has not yet configured iptables."
-      sleep 10
-    done
-
-    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-    server = "$DOCKERHUB_MIRROR"
-    [host."${DOCKERHUB_MIRROR#'https://'}"]
-    capabilities = ["pull", "resolve"]
-  EOF
-    microk8s stop
-    microk8s start
-  fi
 
   if [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
   then
-    concierge prepare --trace -c concierge-microk8s.yaml
-    # microk8s config | juju add-k8s my-k8s --client
-    # juju bootstrap my-k8s concierge-microk8s
-    # juju add-model --controller concierge-microk8s testing
+    concierge prepare --trace -c concierge-k8s.yaml
+    # k8s status --wait-ready returns as soon as 1 node is ready
+    # (see https://github.com/canonical/k8s-snap/issues/1789)
+    # but Cilium, CoreDNS, and storage may still be initialising
+    for res in deployment/cilium-operator deployment/coredns deployment/metrics-server daemonset/cilium daemonset/ck-storage-rawfile-csi-node statefulset/ck-storage-rawfile-csi-controller; do
+        if k8s kubectl -n kube-system get "$res" >/dev/null 2>&1; then
+            k8s kubectl -n kube-system rollout status "$res" --timeout=5m
+        else
+            echo "Skipping rollout status for missing $res"
+        fi
+    done
   fi
 
   if [[ $SPREAD_SUITE == *"vm"* ]]
@@ -172,13 +154,11 @@ prepare: |
     if [[ $SPREAD_TASK == *"oauth"* ]]
     then
       mkdir -p ~/.kube
-      microk8s.kubectl config view --raw > ~/.kube/config
+      k8s kubectl config view --raw > ~/.kube/config
       export LOCAL_IP="127.0.0.1"
       export PUBLIC_IP=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
       sed -i 's/'${LOCAL_IP}'/'${PUBLIC_IP}'/g' ~/.kube/config
       cat ~/.kube/config | juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
-      # microk8s config | juju add-k8s uk8s --client
-      # juju add-model --controller concierge-lxd testing-uk8s
     fi
   fi
 
@@ -192,14 +172,14 @@ prepare-each: |
   then
     concierge prepare --trace -c concierge-lxd.yaml
   else
-    concierge prepare --trace -c concierge-microk8s.yaml
+    concierge prepare --trace -c concierge-k8s.yaml
   fi
 
   if [[ $SPREAD_SUITE == *"vm"* ]]
   then
     juju switch concierge-lxd
   else
-    juju switch concierge-microk8s
+    juju switch concierge-k8s
   fi
 
   # Unable to set constraint on all models because of Juju bug:

--- a/spread.yaml
+++ b/spread.yaml
@@ -133,16 +133,6 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
-  then
-    mkdir -p /var/snap/k8s/common/etc/containerd/certs.d/docker.io
-    tee /var/snap/k8s/common/etc/containerd/certs.d/docker.io/hosts.toml << EOF
-    server = "$DOCKERHUB_MIRROR"
-    [host."${DOCKERHUB_MIRROR#'https://'}"]
-    capabilities = ["pull", "resolve"]
-  EOF
-  fi
-
   if [[ $SPREAD_SUITE == *"k8s"* || $SPREAD_TASK == *"oauth"* ]]
   then
     concierge prepare --trace -c concierge-k8s.yaml

--- a/tests/integration/ha/k8s_helpers/deploy_chaos_mesh.sh
+++ b/tests/integration/ha/k8s_helpers/deploy_chaos_mesh.sh
@@ -12,13 +12,13 @@ if [ -z "${chaos_mesh_ns}" ]; then
 fi
 
 deploy_chaos_mesh() {
-    if [ "$(microk8s.helm repo list | grep -c 'chaos-mesh')" != "1" ]; then
-        echo "adding chaos-mesh microk8s.helm repo"
-        microk8s.helm repo add chaos-mesh https://charts.chaos-mesh.org
+    if [ "$(sudo k8s helm repo list | grep -c 'chaos-mesh')" != "1" ]; then
+        echo "adding chaos-mesh k8s helm repo"
+        sudo k8s helm repo add chaos-mesh https://charts.chaos-mesh.org
     fi
 
     echo "installing chaos-mesh"
-    microk8s.helm install chaos-mesh chaos-mesh/chaos-mesh --namespace="${chaos_mesh_ns}" --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock --set dashboard.create=false --version "${chaos_mesh_version}" --set clusterScoped=false --set controllerManager.targetNamespace="${chaos_mesh_ns}"
+    sudo k8s helm install chaos-mesh chaos-mesh/chaos-mesh --namespace="${chaos_mesh_ns}" --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --set dashboard.create=false --version "${chaos_mesh_version}" --set clusterScoped=false --set controllerManager.targetNamespace="${chaos_mesh_ns}"
     sleep 10
 }
 

--- a/tests/integration/ha/k8s_helpers/destroy_chaos_mesh.sh
+++ b/tests/integration/ha/k8s_helpers/destroy_chaos_mesh.sh
@@ -13,38 +13,38 @@ fi
 destroy_chaos_mesh() {
     # 1. Let Helm attempt a graceful uninstall first.
     # (If we delete CRDs/Webhooks first, Helm usually hangs or fails)
-    if [ "$(microk8s.helm list --namespace "${chaos_mesh_ns}" | grep -c 'chaos-mesh')" -ge "1" ]; then
+    if [ "$(sudo k8s helm list --namespace "${chaos_mesh_ns}" | grep -c 'chaos-mesh')" -ge "1" ]; then
         echo "uninstalling chaos-mesh helm release..."
-        microk8s.helm uninstall chaos-mesh --namespace "${chaos_mesh_ns}" || :
+        sudo k8s helm uninstall chaos-mesh --namespace "${chaos_mesh_ns}" || :
     fi
 
     # 2. Delete custom chaos resources
     echo "deleting api-resources..."
-    for i in $(kubectl api-resources | grep -i 'chaos-mesh' | awk '{print $1}'); do
-        timeout 30 kubectl delete "${i}" --all --all-namespaces || :
+    for i in $(sudo k8s kubectl api-resources | grep -i 'chaos-mesh' | awk '{print $1}'); do
+        timeout 30 sudo k8s kubectl delete "${i}" --all --all-namespaces || :
     done
 
     # 3. Webhook configurations are cluster-scoped (removing the -n flag)
     echo "deleting mutating and validating webhooks..."
-    kubectl get mutatingwebhookconfiguration -o name | grep -i 'chaos-mesh' | xargs -r timeout 30 kubectl delete || :
-    kubectl get validatingwebhookconfiguration -o name | grep -i 'chaos-mesh' | xargs -r timeout 30 kubectl delete || :
+    sudo k8s kubectl get mutatingwebhookconfiguration -o name | grep -i 'chaos-mesh' | xargs -r timeout 30 sudo k8s kubectl delete || :
+    sudo k8s kubectl get validatingwebhookconfiguration -o name | grep -i 'chaos-mesh' | xargs -r timeout 30 sudo k8s kubectl delete || :
 
     # 4. Use xargs to safely pass multiple arguments for deletion
     echo "deleting clusterrolebindings..."
-    kubectl get clusterrolebinding -o name | grep -i 'chaos-mesh' | xargs -r timeout 30 kubectl delete || :
+    sudo k8s kubectl get clusterrolebinding -o name | grep -i 'chaos-mesh' | xargs -r timeout 30 sudo k8s kubectl delete || :
 
     echo "deleting clusterroles..."
-    kubectl get clusterrole -o name | grep -i 'chaos-mesh' | xargs -r timeout 30 kubectl delete || :
+    sudo k8s kubectl get clusterrole -o name | grep -i 'chaos-mesh' | xargs -r timeout 30 sudo k8s kubectl delete || :
 
     echo "removing finalizers from crds to prevent hanging..."
-    kubectl get crd -o name | grep -i 'chaos-mesh.org' | xargs -r -I {} kubectl patch {} -p '{"metadata":{"finalizers":[]}}' --type=merge || :
+    sudo k8s kubectl get crd -o name | grep -i 'chaos-mesh.org' | xargs -r -I {} sudo k8s kubectl patch {} -p '{"metadata":{"finalizers":[]}}' --type=merge || :
 
     echo "deleting crds..."
-    kubectl get crd -o name | grep -i 'chaos-mesh.org' | xargs -r timeout 30 kubectl delete || :
+    sudo k8s kubectl get crd -o name | grep -i 'chaos-mesh.org' | xargs -r timeout 30 sudo k8s kubectl delete || :
 
     # 5. Clean up any leftover hanging resources in the namespace
     echo "cleaning up leftover namespace resources..."
-    kubectl delete all -l app.kubernetes.io/instance=chaos-mesh -n "${chaos_mesh_ns}" || :
+    sudo k8s kubectl delete all -l app.kubernetes.io/instance=chaos-mesh -n "${chaos_mesh_ns}" || :
 }
 
 echo "Destroying chaos mesh in ${chaos_mesh_ns}"

--- a/tests/integration/ha/k8s_helpers/helpers.py
+++ b/tests/integration/ha/k8s_helpers/helpers.py
@@ -73,7 +73,7 @@ def k8s_cut_network_from_unit_without_ip_change(model_name: str, machine_name: s
         env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
         try:
             command_result = subprocess.check_output(
-                ["microk8s", "kubectl", "apply", "-f", temp_file.name],
+                ["sudo", "k8s", "kubectl", "apply", "-f", temp_file.name],
                 env=env,
                 stderr=subprocess.STDOUT,
             )
@@ -94,7 +94,7 @@ def k8s_restore_network_to_unit(model_name: str) -> None:
     env = os.environ
     env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
     subprocess.check_output(
-        f"microk8s kubectl -n {model_name} delete networkchaos network-loss-primary",
+        f"sudo k8s kubectl -n {model_name} delete networkchaos network-loss-primary",
         shell=True,
         env=env,
     )

--- a/tests/integration/relations/conftest.py
+++ b/tests/integration/relations/conftest.py
@@ -11,29 +11,29 @@ from juju.controller import Controller
 from juju.model import Model
 from pytest_operator.plugin import OpsTest
 
-MICROK8S_CLOUD_NAME = "uk8s"
+K8S_CLOUD_NAME = "uk8s"
 
 
 @pytest.fixture(scope="module")
-async def ops_test_microk8s(
+async def ops_test_k8s(
     request, tmp_path_factory, ops_test: OpsTest, substrate
 ) -> AsyncGenerator[OpsTest, Any]:
-    """Create second OpsTest object, that is connected to the MicroK8s cloud.
+    """Create second OpsTest object, that is connected to the k8s cloud.
 
     Automatically creates and destroys (unless keep models parameter is used)
-    corresponding Juju model. MicroK8s and uk8s cloud are set up by spread prepare
+    corresponding Juju model. k8s and uk8s cloud are set up by spread prepare
     for OAuth tests.
 
     Returns:
-        OpsTest object with MicroK8s connection and Juju model.
+        OpsTest object with k8s connection and Juju model.
     """
     if substrate == "k8s":
         yield ops_test
         return
 
-    model_name = f"{ops_test.model_name}-{MICROK8S_CLOUD_NAME}"
+    model_name = f"{ops_test.model_name}-{K8S_CLOUD_NAME}"
     request.config.option.controller = ops_test.controller_name
-    request.config.option.cloud = MICROK8S_CLOUD_NAME
+    request.config.option.cloud = K8S_CLOUD_NAME
     request.config.option.model = model_name
     request.config.option.model_alias = model_name
     ops_res = OpsTest(request, tmp_path_factory)
@@ -54,8 +54,8 @@ async def application_charm() -> str:
 
 
 @pytest.fixture(scope="module")
-async def microk8s_model(ops_test: OpsTest, substrate) -> AsyncGenerator[Model, Any]:
-    """Create new Juju model on the connected MicroK8s cloud.
+async def k8s_model(ops_test: OpsTest, substrate) -> AsyncGenerator[Model, Any]:
+    """Create new Juju model on the connected k8s cloud.
 
     Automatically destroys that model unless keep models parameter is used.
 
@@ -66,13 +66,13 @@ async def microk8s_model(ops_test: OpsTest, substrate) -> AsyncGenerator[Model, 
         assert ops_test.model is not None, "OpsTest model is not connected"
         yield ops_test.model
         return
-    model_name = f"{ops_test.model_name}-{MICROK8S_CLOUD_NAME}"
+    model_name = f"{ops_test.model_name}-{K8S_CLOUD_NAME}"
     controller = Controller()
     await controller.connect()
     if model_name in await controller.list_models():
         model = await controller.get_model(model_name)
     else:
-        model = await controller.add_model(model_name, cloud_name=MICROK8S_CLOUD_NAME)
+        model = await controller.add_model(model_name, cloud_name=K8S_CLOUD_NAME)
 
     yield model
 

--- a/tests/integration/relations/test_oauth.py
+++ b/tests/integration/relations/test_oauth.py
@@ -49,10 +49,10 @@ logger = logging.getLogger(__name__)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
 async def test_deploy(
-    ops_test: OpsTest, charm, series, ops_test_microk8s: OpsTest, charm_resources, substrate
+    ops_test: OpsTest, charm, series, ops_test_k8s: OpsTest, charm_resources, substrate
 ):
     """Deploy OpenSearch, data integrator and identity platform (K8s) simultaneously."""
-    k8s_ops = ops_test_microk8s if substrate == "vm" else ops_test
+    k8s_ops = ops_test_k8s if substrate == "vm" else ops_test
     await gather(
         ops_test.model.deploy(
             charm,
@@ -78,7 +78,7 @@ async def test_deploy(
 
 
 @pytest.mark.abort_on_fail
-async def test_setup_relations(ops_test: OpsTest, microk8s_model: Model, substrate):
+async def test_setup_relations(ops_test: OpsTest, k8s_model: Model, substrate):
     """Establish all the required relations.
 
     Connects OpenSearch, data integrator and identity platform (cross-model).
@@ -89,14 +89,12 @@ async def test_setup_relations(ops_test: OpsTest, microk8s_model: Model, substra
         await ops_test.model.integrate(f"{APP_NAME}:certificates", "self-signed-certificates")
         await ops_test.model.integrate(f"{APP_NAME}:oauth", "hydra")
     else:
-        await microk8s_model.create_offer(
-            "certificates", "certificates", "self-signed-certificates"
-        )
-        await ops_test.model.consume(f"admin/{microk8s_model.name}.certificates")
+        await k8s_model.create_offer("certificates", "certificates", "self-signed-certificates")
+        await ops_test.model.consume(f"admin/{k8s_model.name}.certificates")
         await ops_test.model.integrate("opensearch:certificates", "certificates")
 
-        await microk8s_model.create_offer("oauth", "oauth", "hydra")
-        await ops_test.model.consume(f"admin/{microk8s_model.name}.oauth")
+        await k8s_model.create_offer("oauth", "oauth", "hydra")
+        await ops_test.model.consume(f"admin/{k8s_model.name}.oauth")
         await ops_test.model.integrate("opensearch:oauth", "oauth")
 
     await ops_test.model.integrate(
@@ -107,22 +105,22 @@ async def test_setup_relations(ops_test: OpsTest, microk8s_model: Model, substra
     await gather(
         ops_test.model.wait_for_idle(apps=[APP_NAME, DATA_INTEGRATOR_NAME], status="active"),
         # we can get a blocked status on kratos-external-idp-integrator
-        # but setup can still proceed, so we don't check for active status on microk8s model
-        microk8s_model.wait_for_idle(timeout=1200),
+        # but setup can still proceed, so we don't check for active status on k8s model
+        k8s_model.wait_for_idle(timeout=1200),
     )
 
 
 @pytest.mark.abort_on_fail
-async def test_setup_oauth(ops_test: OpsTest, microk8s_model: Model):
+async def test_setup_oauth(ops_test: OpsTest, k8s_model: Model):
     """Configure new OAuth client on Hydra (identity platform).
 
     Also, acquire corresponding access token for the further testing.
     """
     # Ensure Hydra is active before running the action
-    await microk8s_model.wait_for_idle(apps=["hydra"], status="active", timeout=300)
+    await k8s_model.wait_for_idle(apps=["hydra"], status="active", timeout=300)
 
     action: Action = (
-        await microk8s_model.applications["hydra"]
+        await k8s_model.applications["hydra"]
         .units[0]
         .run_action(
             "create-oauth-client",
@@ -146,7 +144,7 @@ async def test_setup_oauth(ops_test: OpsTest, microk8s_model: Model):
         raise AssertionError(msg)
 
     action = (
-        await microk8s_model.applications["traefik-public"]
+        await k8s_model.applications["traefik-public"]
         .units[0]
         .run_action("show-proxied-endpoints")
     )
@@ -180,7 +178,7 @@ async def test_setup_oauth(ops_test: OpsTest, microk8s_model: Model):
 
 
 @pytest.mark.abort_on_fail
-async def test_oauth_access(ops_test: OpsTest, microk8s_model: Model):
+async def test_oauth_access(ops_test: OpsTest, k8s_model: Model):
     """Check access to the OpenSearch with an access token, acquired earlier.
 
     Ensure that roles mapping works correctly by elevating user
@@ -224,7 +222,7 @@ async def test_oauth_access(ops_test: OpsTest, microk8s_model: Model):
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_second_client(ops_test: OpsTest, microk8s_model: Model):
+async def test_deploy_second_client(ops_test: OpsTest, k8s_model: Model):
     """Deploy and configure second data integrator."""
     await ops_test.model.deploy(
         DATA_INTEGRATOR_NAME,
@@ -237,7 +235,7 @@ async def test_deploy_second_client(ops_test: OpsTest, microk8s_model: Model):
 
 
 @pytest.mark.abort_on_fail
-async def test_oauth_access_second_client(ops_test: OpsTest, microk8s_model: Model):
+async def test_oauth_access_second_client(ops_test: OpsTest, k8s_model: Model):
     """Change roles mapping from first data integrator user to second one.
 
     Ensure, that admin permissions from the first one is removed, while role
@@ -289,7 +287,7 @@ async def test_oauth_access_second_client(ops_test: OpsTest, microk8s_model: Mod
 
 
 @pytest.mark.abort_on_fail
-async def test_oauth_access_cleanup(ops_test: OpsTest, microk8s_model: Model):
+async def test_oauth_access_cleanup(ops_test: OpsTest, k8s_model: Model):
     """Ensure that all of the oauth clients permissions are removed with clean roles mapping."""
     await ops_test.model.applications["opensearch"].set_config(original_opensearch_config)
     await ops_test.model.wait_for_idle(apps=["opensearch"], status="active")
@@ -305,7 +303,7 @@ async def test_oauth_access_cleanup(ops_test: OpsTest, microk8s_model: Model):
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9182")
-async def test_setup_large_cluster(ops_test: OpsTest, charm, series, microk8s_model: Model):
+async def test_setup_large_cluster(ops_test: OpsTest, charm, series, k8s_model: Model):
     """Replace the Opensearch application with a large deployment cluster."""
     logger.info("Remove Opensearch application")
     await ops_test.model.remove_application("opensearch", block_until_done=True)
@@ -362,7 +360,7 @@ async def test_setup_large_cluster(ops_test: OpsTest, charm, series, microk8s_mo
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9182")
-async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, microk8s_model: Model):
+async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, k8s_model: Model):
     """Ensure OAuth cannot be enabled if related to non-main-orchestrator."""
     logger.info(f"Integrating {DATA_APP} with OAuth - this will result in blocked status")
     await ops_test.model.integrate(f"{DATA_APP}:oauth", "oauth")
@@ -397,7 +395,7 @@ async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, micro
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip(reason="https://warthogs.atlassian.net/browse/DPE-9182")
-async def test_oauth_access_large_cluster(ops_test: OpsTest, charm, series, microk8s_model: Model):
+async def test_oauth_access_large_cluster(ops_test: OpsTest, charm, series, k8s_model: Model):
     """Relate to main orchestrator and verify access with OAuth."""
     logger.info(f"Integrating {MAIN_APP} with oauth")
     await ops_test.model.integrate(f"{MAIN_APP}:oauth", "oauth")


### PR DESCRIPTION
## Switch CI from MicroK8s to canonical k8s snap

### Summary

- Replaces the MicroK8s provider in CI with the canonical `k8s` snap (`1.32-classic/stable`),
  aligned with how Canonical now ships and supports Kubernetes in spread/CI environments
- Removes the DockerHub mirror workaround that was only needed for MicroK8s on IS-hosted runners
- Adds explicit readiness waits for core k8s components (Cilium, CoreDNS, metrics-server,
  storage) after bootstrap, working around
  [k8s-snap#1789](https://github.com/canonical/k8s-snap/issues/1789) where
  `k8s status --wait-ready` returns before all workloads are ready
- Updates all `microk8s.kubectl` / `microk8s.helm` calls to `sudo k8s kubectl` /
  `sudo k8s helm` across chaos mesh scripts and test helpers
- Renames test fixtures and constants from `microk8s_*` to `k8s_*`
  (e.g. `ops_test_microk8s` → `ops_test_k8s`, `microk8s_model` → `k8s_model`,
  `MICROK8S_CLOUD_NAME` → `K8S_CLOUD_NAME`) for clarity

### Test plan

- [ ] Spread k8s suite runs end-to-end on a self-hosted runner with the canonical k8s snap
- [ ] OAuth tests (which use a cross-model k8s cloud) continue to pass
- [ ] Chaos network tests (deploy/destroy chaos-mesh) continue to work with the updated
      helm/kubectl commands